### PR TITLE
BUGFIX: Insert extra checks for `StaticText.html`

### DIFF
--- a/Resources/Private/Form/StaticText.html
+++ b/Resources/Private/Form/StaticText.html
@@ -1,4 +1,8 @@
-<f:if condition="{element.label}">
-	<h2>{element.label}</h2>
-</f:if>
-<p{f:if(condition: element.properties.elementClassAttribute, then: ' class="{element.properties.elementClassAttribute}"')}>{element.properties.text -> f:format.nl2br()}</p>
+<div{f:if(condition: element.properties.containerClassAttribute, then: ' class="{element.properties.containerClassAttribute}"')}>
+	<f:if condition="{element.label}">
+		<h2>{element.label}</h2>
+	</f:if>
+	<f:if condition="{element.properties.text}">
+		<p{f:if(condition: element.properties.elementClassAttribute, then: ' class="{element.properties.elementClassAttribute}"')}>{element.properties.text -> f:format.nl2br()}</p>
+	</f:if>
+</div>


### PR DESCRIPTION
Output `containerClassAttribute` (if set) and only output `element.properties.text` if set. 
Otherwise the result might be an empty `<p>` tag within the form.

FLOW-375 #close
