### PR TITLE
[BUGFIX] Only apply processing rules if value not NULL

### DIFF
--- a/Classes/TYPO3/Form/Core/Runtime/FormRuntime.php
+++ b/Classes/TYPO3/Form/Core/Runtime/FormRuntime.php
@@ -257,7 +257,9 @@ class FormRuntime implements \TYPO3\Form\Core\Model\Renderable\RootRenderableInt
 			$element->onSubmit($this, $value);
 
 			$this->formState->setFormValue($element->getIdentifier(), $value);
-			$registerPropertyPaths($element->getIdentifier());
+			if ($value !== NULL) {
+				$registerPropertyPaths($element->getIdentifier());
+			}
 		}
 
 		// The more parts the path has, the more early it is processed


### PR DESCRIPTION
As some TypeConverters do not accept a NULL value the
processing rules should only be applied if the value is
not NULL.