### PR TITLE
BUGFIX: Make class in SingleSelectDropdown configurable

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -137,6 +137,8 @@ TYPO3:
             superTypes:
               'TYPO3.Form:FormElement': TRUE
               'TYPO3.Form:SingleSelectionMixin': TRUE
+            properties:
+              elementClassAttribute: 'xlarge'
           'TYPO3.Form:SingleSelectDropdown':
             superTypes:
               'TYPO3.Form:FormElement': TRUE

--- a/Resources/Private/Form/SingleSelectDropdown.html
+++ b/Resources/Private/Form/SingleSelectDropdown.html
@@ -1,4 +1,4 @@
 <f:layout name="TYPO3.Form:Field" />
 <f:section name="field">
-	<f:form.select property="{element.identifier}" id="{element.uniqueIdentifier}" options="{element.properties.options}" class="xlarge" errorClass="{element.properties.elementErrorClassAttribute}" />
+	<f:form.select property="{element.identifier}" id="{element.uniqueIdentifier}" options="{element.properties.options}" class="{element.properties.elementClassAttribute}" errorClass="{element.properties.elementErrorClassAttribute}" />
 </f:section>


### PR DESCRIPTION
This makes the class attribute in the template for
TYPO3.Form:SingleSelectDropdown configurable like
in every other field element template.