### PR TITLE
TASK: Change field type to date to enable HTML5 date selector

### DIFF
--- a/Classes/TYPO3/Form/ViewHelpers/Form/DatePickerViewHelper.php
+++ b/Classes/TYPO3/Form/ViewHelpers/Form/DatePickerViewHelper.php
@@ -12,13 +12,14 @@ namespace TYPO3\Form\ViewHelpers\Form;
  *                                                                        */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
 
 /**
  * Display a jQuery date picker.
  *
  * Note: Requires jQuery UI to be included on the page.
  */
-class DatePickerViewHelper extends \TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper
+class DatePickerViewHelper extends AbstractFormFieldViewHelper
 {
     /**
      * @var string
@@ -26,7 +27,7 @@ class DatePickerViewHelper extends \TYPO3\Fluid\ViewHelpers\Form\AbstractFormFie
     protected $tagName = 'input';
 
     /**
-     * @var TYPO3\Flow\Property\PropertyMapper
+     * @var \TYPO3\Flow\Property\PropertyMapper
      * @Flow\Inject
      */
     protected $propertyMapper;
@@ -60,7 +61,7 @@ class DatePickerViewHelper extends \TYPO3\Fluid\ViewHelpers\Form\AbstractFormFie
         $name = $this->getName();
         $this->registerFieldNameForFormTokenGeneration($name);
 
-        $this->tag->addAttribute('type', 'text');
+        $this->tag->addAttribute('type', 'date');
         $this->tag->addAttribute('name', $name . '[date]');
         if ($enableDatePicker) {
             $this->tag->addAttribute('readonly', true);


### PR DESCRIPTION
Currently the date selector uses jQuery UI for the date selector.
This PR changes the field type for the date selector to "date"
to enable the HTML5 date selector as soon you disable the
jQuery script.