### PR TITLE
TASK: Fix docblock to avoid rST syntax errors

### DIFF
--- a/Classes/TYPO3/Form/ViewHelpers/RenderViewHelper.php
+++ b/Classes/TYPO3/Form/ViewHelpers/RenderViewHelper.php
@@ -20,9 +20,6 @@ use TYPO3\Form\Persistence\FormPersistenceManagerInterface;
 /**
  * Main Entry Point to render a Form into a Fluid Template
  *
- * Usage
- * =====
- *
  * <pre>
  * {namespace form=TYPO3\Form\ViewHelpers}
  * <form:render factoryClass="NameOfYourCustomFactoryClass" />


### PR DESCRIPTION
This avoids a syntax error in the auto-generated rST ViewHelper reference.