### PR TITLE
FEATURE: Translate form values in EmailFinisher

### DIFF
--- a/Classes/TYPO3/Form/Finishers/RedirectFinisher.php
+++ b/Classes/TYPO3/Form/Finishers/RedirectFinisher.php
@@ -61,14 +61,12 @@ class RedirectFinisher extends AbstractFinisher
         $escapedUri = htmlentities($uri, ENT_QUOTES, 'utf-8');
 
         $response = $formRuntime->getResponse();
-        $mainResponse = $response;
-        while ($response = $response->getParentResponse()) {
-            $mainResponse = $response;
-        };
-        $mainResponse->setContent('<html><head><meta http-equiv="refresh" content="' . $delay . ';url=' . $escapedUri . '"/></head></html>');
-        $mainResponse->setStatus($statusCode);
+
+        $response->setContent('<html><head><meta http-equiv="refresh" content="' . $delay . ';url=' . $escapedUri . '"/></head></html>');
+        $response->setStatus($statusCode);
+
         if ($delay === 0) {
-            $mainResponse->setHeader('Location', (string)$uri);
+            $response->setHeader('Location', (string)$uri);
         }
     }
 

--- a/Classes/TYPO3/Form/Finishers/RedirectFinisher.php
+++ b/Classes/TYPO3/Form/Finishers/RedirectFinisher.php
@@ -10,23 +10,27 @@ namespace TYPO3\Form\Finishers;
  *                                                                        *
  * The TYPO3 project - inspiring people to share!                         *
  *                                                                        */
+use TYPO3\Flow\Mvc\ActionRequest;
+use TYPO3\Flow\Mvc\Routing\UriBuilder;
+use TYPO3\Form\Core\Model\AbstractFinisher;
 
 /**
- * This finisher redirects to another Controller.
+ * This finisher redirects to another Controller or a specific URI.
  */
-class RedirectFinisher extends \TYPO3\Form\Core\Model\AbstractFinisher
+class RedirectFinisher extends AbstractFinisher
 {
     /**
      * @var array
      */
-    protected $defaultOptions = array(
+    protected $defaultOptions = [
         'package' => null,
         'controller' => null,
         'action' => '',
-        'arguments' => array(),
+        'arguments' => [],
+        'uri' => '',
         'delay' => 0,
-        'statusCode' => 303,
-    );
+        'statusCode' => 303
+    ];
 
     /**
      * Executes this finisher
@@ -40,23 +44,20 @@ class RedirectFinisher extends \TYPO3\Form\Core\Model\AbstractFinisher
         $formRuntime = $this->finisherContext->getFormRuntime();
         $request = $formRuntime->getRequest()->getMainRequest();
 
-        $packageKey = $this->parseOption('package');
-        $controllerName = $this->parseOption('controller');
-        $actionName = $this->parseOption('action');
-        $arguments = $this->parseOption('arguments');
         $delay = (integer)$this->parseOption('delay');
         $statusCode = $this->parseOption('statusCode');
+        $uri = trim($this->parseOption('uri'));
 
-        $subpackageKey = null;
-        if ($packageKey !== null && strpos($packageKey, '\\') !== false) {
-            list($packageKey, $subpackageKey) = explode('\\', $packageKey, 2);
+        
+        if ($uri === '') {
+            $uri = $this->buildActionUri($request);
         }
-        $uriBuilder = new \TYPO3\Flow\Mvc\Routing\UriBuilder();
-        $uriBuilder->setRequest($request);
-        $uriBuilder->reset();
 
-        $uri = $uriBuilder->uriFor($actionName, $arguments, $controllerName, $packageKey, $subpackageKey);
-        $uri = $request->getHttpRequest()->getBaseUri() . $uri;
+        $uriParts = parse_url($uri);
+        if (!isset($uriParts['scheme']) || $uriParts['scheme'] === '') {
+            $uri = $request->getHttpRequest()->getBaseUri() . $uri;
+        }
+
         $escapedUri = htmlentities($uri, ENT_QUOTES, 'utf-8');
 
         $response = $formRuntime->getResponse();
@@ -79,5 +80,28 @@ class RedirectFinisher extends \TYPO3\Form\Core\Model\AbstractFinisher
     public function setOptions(array $options)
     {
         $this->options = $options;
+    }
+
+    /**
+     * @param ActionRequest $request
+     * @return string
+     */
+    protected function buildActionUri(ActionRequest $request)
+    {
+        $packageKey = $this->parseOption('package');
+        $controllerName = $this->parseOption('controller');
+        $actionName = $this->parseOption('action');
+        $arguments = $this->parseOption('arguments');
+
+        $subpackageKey = null;
+        if ($packageKey !== null && strpos($packageKey, '\\') !== false) {
+            list($packageKey, $subpackageKey) = explode('\\', $packageKey, 2);
+        }
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($request);
+        $uriBuilder->reset();
+
+        $uri = $uriBuilder->uriFor($actionName, $arguments, $controllerName, $packageKey, $subpackageKey);
+        return $uri;
     }
 }

--- a/Documentation/translating-forms.rst
+++ b/Documentation/translating-forms.rst
@@ -265,16 +265,18 @@ To enable translation in EmailFinisher set ``translation.enabled: true``. The op
 
 ### Example email template
 
+The translated values are stored in {translatedFormState}.
+
 .. code-block:: txt
 
 {namespace form=TYPO3\Form\ViewHelpers}
 
 {f:translate(id: "email.contact.text", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}
 
-{f:translate(id: "forms.elements.reason.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {form.formState.formValues.reason}
-{f:translate(id: "forms.elements.name.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {form.formState.formValues.name}
-{f:translate(id: "forms.elements.email.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {form.formState.formValues.email}
+{f:translate(id: "forms.elements.reason.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {translatedFormState.formValues.reason}
+{f:translate(id: "forms.elements.name.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {translatedFormState.formValues.name}
+{f:translate(id: "forms.elements.email.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {translatedFormState.formValues.email}
 
 {f:translate(id: "forms.elements.message.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}
 
-{form.formState.formValues.message}
+{translatedFormState.formValues.message}

--- a/Documentation/translating-forms.rst
+++ b/Documentation/translating-forms.rst
@@ -69,7 +69,7 @@ forms.navigation.previousPage
 forms.navigation.submitButton
   In forms this is used for the submit button.
 
-Forms and sections can have their labels translated using this, where where ``{identifier}`` is the identifier
+Forms and sections can have their labels translated using this, where ``{identifier}`` is the identifier
 of the page or section itself:
 
 forms.pages.{identifier}.label
@@ -142,6 +142,17 @@ Assume it is configured like this using YAML:
             properties:
               placeholder: 'Enter a valid email address'
           -
+            type: 'TYPO3.Form:SingleSelectDropdown'
+            identifier: 'reason'
+            label: 'Reason'
+            validators:
+              - identifier: 'TYPO3.Flow:NotEmpty'
+            properties:
+              options:
+                '': 'Choose an option ...'
+                'general': 'General Question'
+                'product': 'Question concerning a product'
+          -
             type: 'TYPO3.Form:MultiLineText'
             identifier: message
             label: 'Message'
@@ -196,9 +207,74 @@ The following XLIFF would allow to translate the form:
                 <trans-unit id="forms.elements.message.placeholder" xml:space="preserve">
                     <source>Enter your message here</source>
                 </trans-unit>
+
+                <trans-unit id="forms.elements.reason.label" xml:space="preserve">
+                    <source>Reason</source>
+                </trans-unit>                
+                <trans-unit id="forms.elements.reason.options." xml:space="preserve">
+                    <source>Choose an option ...</source>
+                </trans-unit>
+                <trans-unit id="forms.elements.reason.options.general" xml:space="preserve">
+                    <source>General Question</source>
+                </trans-unit>
+                <trans-unit id="forms.elements.reason.options.product" xml:space="preserve">
+                    <source>Question concerning a product</source>
+                </trans-unit>
+                <trans-unit id="email.contact.text" xml:space="preserve">
+                    <source>The contact form has been submitted with the following values</source>
+                </trans-unit>
             </body>
         </file>
     </xliff>
 
 Copy it to your target language and add the ``target-language`` attribute as well as the needed
 ``<target>…</target>`` entries.
+
+Translate email template
+------------------------
+
+To make use of translations in i.e. email templates you can use the fluid translate viewhelper ``<f:translate id="..." package= "{translation.package}", source= "{translation.source}", locale= "{translation.locale}">``.
+
+The translation configuration for EmailFinisher can be configured via yaml
+
+.. code-block:: yaml
+
+    type: 'TYPO3.Form:Form'
+    identifier: 'contact'
+    label: 'Contact form'
+    renderables:
+      ...
+          
+    finishers:
+      -
+        identifier: 'TYPO3.Form:Email'
+        options:
+          templatePathAndFilename: resource://AcmeCom.SomePackage/Private/Templates/Form/Contact.txt
+          subject: '{subject}'
+          recipientAddress: 'info@acme.com'
+          recipientName: 'Acme Customer Care'
+          senderAddress: '{email}'
+          senderName: '{name}'
+          format: plaintext
+          translation.enabled: true
+          translation.package: 'AcmeCom.SomePackage'
+          translation.locale: 'de_DE'
+          translation.source: 'Main'
+
+To enable translation in EmailFinisher set ``translation.enabled: true``. The options ``translation.package``, ``translation.locale``, ``translation.source`` are optional.
+
+### Example email template
+
+.. code-block:: txt
+
+{namespace form=TYPO3\Form\ViewHelpers}
+
+{f:translate(id: "email.contact.text", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}
+
+{f:translate(id: "forms.elements.reason.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {form.formState.formValues.reason}
+{f:translate(id: "forms.elements.name.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {form.formState.formValues.name}
+{f:translate(id: "forms.elements.email.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}: {form.formState.formValues.email}
+
+{f:translate(id: "forms.elements.message.label", package: "{translation.package}", source: "{translation.source}", locale: "{translation.locale}")}
+
+{form.formState.formValues.message}


### PR DESCRIPTION
To get translated values of selectboxes, checkboxes or radiobuttons in email template the EmailFinisher is extended.
It is now possible to translate finisher options such as subject and submited option values of form elements.
