### PR TITLE
FEATURE: Make the referrer of the form available in Fluid template

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -24,6 +24,8 @@ use Neos\Form\Exception\FinisherException;
  * - partialRootPath: root path for the partials
  * - variables: associative array of variables which are available inside the Fluid template
  *
+ * - referrer: The referrer of the form is available in the Fluid template
+ *
  * The following options control the mail sending. In all of them, placeholders in the form
  * of {...} are replaced with the corresponding form value; i.e. {email} as recipientAddress
  * makes the recipient address configurable.
@@ -66,6 +68,8 @@ class EmailFinisher extends AbstractFinisher
         $formRuntime = $this->finisherContext->getFormRuntime();
         $standaloneView = $this->initializeStandaloneView();
         $standaloneView->assign('form', $formRuntime);
+        $referrer = $formRuntime->getRequest()->getHttpRequest()->getUri();
+        $standaloneView->assign('referrer', $referrer);
         $message = $standaloneView->render();
 
         $subject = $this->parseOption('subject');


### PR DESCRIPTION
Sometimes it is handy to know from which URL a form email was sent,
especially if no external tracking like GA or Piwik is in place.

The referrer can be inserted into the Fluid template using the following
notation: {referrer}.