### PR TITLE
FEATURE: Support multiple recipients in EmailFinisher

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -90,7 +90,7 @@ class EmailFinisher extends AbstractFinisher
             throw new FinisherException('The option "recipientAddress" must be set for the EmailFinisher.', 1327060200);
         }
         if (is_array($recipientAddress) && $recipientName !== '') {
-            throw new \TYPO3\Form\Exception\FinisherException('The option "recipientName" cannot be used with multiple recipients in the EmailFinisher.', 1483365977);
+            throw new FinisherException('The option "recipientName" cannot be used with multiple recipients in the EmailFinisher.', 1483365977);
         }
         if ($senderAddress === null) {
             throw new FinisherException('The option "senderAddress" must be set for the EmailFinisher.', 1327060210);

--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -15,7 +15,7 @@ use Neos\Form\Core\Model\AbstractFinisher;
 use Neos\Form\Exception\FinisherException;
 
 /**
- * This finisher sends an email to one recipient
+ * This finisher sends an email to one or more recipients.
  *
  * Options:
  *
@@ -27,12 +27,11 @@ use Neos\Form\Exception\FinisherException;
  * - referrer: The referrer of the form is available in the Fluid template
  *
  * The following options control the mail sending. In all of them, placeholders in the form
- * of {...} are replaced with the corresponding form value; i.e. {email} as recipientAddress
- * makes the recipient address configurable.
+ * of {...} are replaced with the corresponding form value; i.e. {email} as senderAdress
+ * makes the sender address configurable.
  *
  * - subject (mandatory): Subject of the email
- * - recipientAddress (mandatory): Email address of the recipient
- * - recipientName: Human-readable name of the recipient
+ * - recipients (mandatory): Email(s) of recipients: array('recipient.one@example.com' => 'Recipient One', 'recipient.two@example.com')
  * - senderAddress (mandatory): Email address of the sender
  * - senderName: Human-readable name of the sender
  * - replyToAddress: Email address of to be used as reply-to email (use multiple addresses with an array)
@@ -73,8 +72,7 @@ class EmailFinisher extends AbstractFinisher
         $message = $standaloneView->render();
 
         $subject = $this->parseOption('subject');
-        $recipientAddress = $this->parseOption('recipientAddress');
-        $recipientName = $this->parseOption('recipientName');
+        $recipients = $this->parseOption('recipients');
         $senderAddress = $this->parseOption('senderAddress');
         $senderName = $this->parseOption('senderName');
         $replyToAddress = $this->parseOption('replyToAddress');
@@ -86,8 +84,8 @@ class EmailFinisher extends AbstractFinisher
         if ($subject === null) {
             throw new FinisherException('The option "subject" must be set for the EmailFinisher.', 1327060320);
         }
-        if ($recipientAddress === null) {
-            throw new FinisherException('The option "recipientAddress" must be set for the EmailFinisher.', 1327060200);
+        if ($recipients === null) {
+            throw new FinisherException('The option "recipients" must be set for the EmailFinisher.', 1327060200);
         }
         if ($senderAddress === null) {
             throw new FinisherException('The option "senderAddress" must be set for the EmailFinisher.', 1327060210);
@@ -97,7 +95,7 @@ class EmailFinisher extends AbstractFinisher
 
         $mail
             ->setFrom(array($senderAddress => $senderName))
-            ->setTo(array($recipientAddress => $recipientName))
+            ->setTo($recipients)
             ->setSubject($subject);
 
         if ($replyToAddress !== null) {
@@ -122,7 +120,7 @@ class EmailFinisher extends AbstractFinisher
             \Neos\Flow\var_dump(
                 array(
                     'sender' => array($senderAddress => $senderName),
-                    'recipient' => array($recipientAddress => $recipientName),
+                    'recipients' => $recipients,
                     'replyToAddress' => $replyToAddress,
                     'carbonCopyAddress' => $carbonCopyAddress,
                     'blindCarbonCopyAddress' => $blindCarbonCopyAddress,


### PR DESCRIPTION
This replaces the arguments “recipientName” and “recipientAddress” with
a more generic array argument “recipients”.

Addresses and corresponding names can be entered with key => value,
single addresses as single array values.

This means that the YAML configuration must be updated accordingly:
    …
    recipients:
      ‘recipient.one@example.com’: ‘Recipient One’
      ‘recipient.two@example.com’: ‘Recipient Two’
    …

The following notation also works (if just one recipient is desired):
    …
    recipients: {email}
    …