### PR TITLE
BUGFIX: Do not throw expection if configuration is ``null``

### DIFF
--- a/Classes/TYPO3/Form/Factory/FormFactoryInterface.php
+++ b/Classes/TYPO3/Form/Factory/FormFactoryInterface.php
@@ -41,5 +41,5 @@ interface FormFactoryInterface
      * @return \TYPO3\Form\Core\Model\FormDefinition a newly built form definition
      * @api
      */
-    public function build(array $configuration, $presetName);
+    public function build(array $configuration = [], $presetName);
 }


### PR DESCRIPTION
When calling a form with the ``neos.form:render`` ViewHelper, an exception is thrown if the no empty array is passed with the ``overrideConfiguration`` argument.