### PR TITLE
BUGFIX: Fix code migration

### DIFF
--- a/Migrations/Code/Version20160601101500.php
+++ b/Migrations/Code/Version20160601101500.php
@@ -39,7 +39,7 @@ class Version20160601101500 extends AbstractMigration
 
                 $presetsConfiguration = $this->renameTranslationPackage($presetsConfiguration);
 
-                $configuration['TYPO3']['Form']['presets'] = $presetsConfiguration;
+                $configuration['Neos']['Form']['presets'] = $presetsConfiguration;
             },
             true
         );


### PR DESCRIPTION
With the namespace change the code migration `TYPO3.Form-20160601101500` has not
been adjusted completely, see: https://github.com/neos/form/commit/dfa23c6561e3e5877b8d15197204f8811b1921d3#commitcomment-21736520

As a result, it adds new `TYPO3.Form.*` settings if the settings have been adjusted
to the new namespace (`Neos.Form.*`) already.

This change fixes this.

Fixes: #42