### PR TITLE
BUGFIX: Defer upload validation to form submission

### DIFF
--- a/Classes/FormElements/FileUpload.php
+++ b/Classes/FormElements/FileUpload.php
@@ -24,6 +24,17 @@ class FileUpload extends \Neos\Form\Core\Model\AbstractFormElement
     public function initializeFormElement()
     {
         $this->setDataType(\Neos\Flow\ResourceManagement\PersistentResource::class);
+    }
+
+    /**
+     * Add FileTypeValidator just before submitting so that the "allowedExtension" can be changed at runtime
+     *
+     * @param \Neos\Form\Core\Runtime\FormRuntime $formRuntime
+     * @param mixed $elementValue
+     * @return void
+     */
+    public function onSubmit(\Neos\Form\Core\Runtime\FormRuntime $formRuntime, &$elementValue)
+    {
         $fileTypeValidator = new \Neos\Form\Validation\FileTypeValidator(array('allowedExtensions' => $this->properties['allowedExtensions']));
         $this->addValidator($fileTypeValidator);
     }

--- a/Classes/FormElements/ImageUpload.php
+++ b/Classes/FormElements/ImageUpload.php
@@ -34,6 +34,17 @@ class ImageUpload extends \Neos\Form\Core\Model\AbstractFormElement
         $propertyMappingConfiguration->allowProperties('resource');
 
         $this->setDataType(\Neos\Media\Domain\Model\Image::class);
+    }
+
+    /**
+     * Add ImageTypeValidator just before submitting so that the "allowedTypes" can be changed at runtime
+     *
+     * @param \Neos\Form\Core\Runtime\FormRuntime $formRuntime
+     * @param mixed $elementValue
+     * @return void
+     */
+    public function onSubmit(\Neos\Form\Core\Runtime\FormRuntime $formRuntime, &$elementValue)
+    {
         $imageTypeValidator = new \Neos\Media\Validator\ImageTypeValidator(array('allowedTypes' => $this->properties['allowedTypes']));
         $this->addValidator($imageTypeValidator);
     }


### PR DESCRIPTION
Previously the validation rules for the custom Form Elements
`FileUpload` and `ImageUpload` were configured upon Form Element
initialization.
This had the side effect that changes to the configuration
(e.g. to the "allowedExtensions") that were made at runtime (i.e
not in the form preset) were ignored.