### PR TITLE
TASK: Expose serialized form state from the Form runtime

### DIFF
--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -539,6 +539,16 @@ class FormRuntime implements \Neos\Form\Core\Model\Renderable\RootRenderableInte
     }
 
     /**
+     * @return string
+     * @internal
+     */
+    public function getSerializedFormState()
+    {
+        $serializedFormState = base64_encode(serialize($this->getFormState()));
+        return $this->hashService->appendHmac($serializedFormState);
+    }
+
+    /**
      * Get all rendering options
      *
      * @return array associative array of rendering options

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -11,9 +11,9 @@ namespace Neos\Form\ViewHelpers;
  * source code.
  */
 
-use Neos\FluidAdaptor\ViewHelpers\FormViewHelper as FluidFormViewHelper;
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\FluidAdaptor\ViewHelpers\FormViewHelper as FluidFormViewHelper;
+use Neos\Form\Core\Runtime\FormRuntime;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 /**
@@ -21,12 +21,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  */
 class FormViewHelper extends FluidFormViewHelper
 {
-    /**
-     * @Flow\Inject
-     * @var \Neos\Flow\Security\Cryptography\HashService
-     */
-    protected $hashService;
-
     /**
      * Renders hidden form fields for referrer information about
      * the current request.
@@ -38,8 +32,9 @@ class FormViewHelper extends FluidFormViewHelper
         $tagBuilder = new TagBuilder('input');
         $tagBuilder->addAttribute('type', 'hidden');
         $tagBuilder->addAttribute('name', $this->prefixFieldName('__state'));
-        $serializedFormState = base64_encode(serialize($this->arguments['object']->getFormState()));
-        $tagBuilder->addAttribute('value', $this->hashService->appendHmac($serializedFormState));
+        /** @var FormRuntime $formRuntime */
+        $formRuntime = $this->arguments['object'];
+        $tagBuilder->addAttribute('value', $formRuntime->getSerializedFormState());
         return $tagBuilder->render();
     }
 


### PR DESCRIPTION
The serialized form state is passed through the form pages
so that the form values can't be altered.
This change moves the state serialization from the `FormViewHelper`
to the `FormRuntime` so that it can be reused from other renderers.