### PR TITLE
TASK: FormEditMode Form Element preset

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -25,6 +25,9 @@ Neos:
             rendererClassName: Neos\Form\Core\Renderer\FluidFormRenderer
             renderingOptions:
               renderableNameInTemplate: form
+          'Neos.Form:FormEditMode':
+            superTypes:
+              'Neos.Form:Form': true
           'Neos.Form:RemovableMixin': {  }
           'Neos.Form:ReadOnlyFormElement':
             superTypes:

--- a/Resources/Private/Form/FormEditMode.html
+++ b/Resources/Private/Form/FormEditMode.html
@@ -1,0 +1,6 @@
+{namespace form=Neos\Form\ViewHelpers}
+<form:form action="index" object="{form}" method="post" id="{form.identifier}" section="{form.identifier}" enctype="multipart/form-data">
+	<f:for each="{form.pages}" as="page">
+		<form:renderRenderable renderable="{page}" />
+	</f:for>
+</form:form>


### PR DESCRIPTION
This change adds a new Form Element definition
`Neos.Form:FormEditMode` to the `default` preset that
allows to render the form in an "edit mode" (which usually
displays all form pages and can disable certain interactions
that would affect the UX of form builders)