### PR TITLE
FEATURE: Configurable Form Element render callbacks

### DIFF
--- a/Classes/Core/Renderer/FluidFormRenderer.php
+++ b/Classes/Core/Renderer/FluidFormRenderer.php
@@ -194,6 +194,7 @@ class FluidFormRenderer extends TemplateView implements RendererInterface
         }
 
         $this->baseRenderingContext->setTemplatePaths($currentTemplatePathsResolver);
+        $output = $this->formRuntime->invokeRenderCallbacks($output, $renderable);
         return $output;
     }
 

--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -13,6 +13,7 @@ namespace Neos\Form\Core\Runtime;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Form\Core\Model\Renderable\RootRenderableInterface;
 
 /**
  * This class implements the *runtime logic* of a form, i.e. deciding which
@@ -116,6 +117,11 @@ class FormRuntime implements \Neos\Form\Core\Model\Renderable\RootRenderableInte
      * @internal
      */
     protected $flashMessageContainer;
+
+    /**
+     * @var callable[]
+     */
+    protected $renderCallbacks = [];
 
     /**
      * @param \Neos\Form\Core\Model\FormDefinition $formDefinition
@@ -594,5 +600,32 @@ class FormRuntime implements \Neos\Form\Core\Model\Renderable\RootRenderableInte
      */
     public function beforeRendering(\Neos\Form\Core\Runtime\FormRuntime $formRuntime)
     {
+    }
+
+    /**
+     * Registers a callback that is called just before a Form Element is rendered.
+     * The callback will be invoked with the rendered element and an instance of the RootRenderableInterface as
+     * arguments and is expected to return the (possibly altered) rendered element
+     *
+     * @param callable $callback
+     * @return void
+     * @api
+     */
+    public function registerRenderCallback(callable $callback)
+    {
+        $this->renderCallbacks[] = $callback;
+    }
+
+    /**
+     * @param string $renderedElement
+     * @param RootRenderableInterface $renderable
+     * @return string
+     */
+    public function invokeRenderCallbacks($renderedElement, RootRenderableInterface $renderable)
+    {
+        foreach ($this->renderCallbacks as $renderCallback) {
+            $renderedElement = call_user_func($renderCallback, $renderedElement, $renderable);
+        }
+        return $renderedElement;
     }
 }

--- a/Documentation/extending-form-api.rst
+++ b/Documentation/extending-form-api.rst
@@ -164,6 +164,7 @@ list. A Form Element Renderer must implement the ``RendererInterface`` interface
 	    * @return string
 	    */
 	   public function renderRenderable(\Neos\Form\Core\Model\Renderable\RootRenderableInterface $renderable) {
+	      $renderable->beforeRendering($this->formRuntime);
 	      $items = array();
 	      if ($renderable instanceof \Neos\Form\Core\Model\FormElementInterface) {
 	         $elementProperties = $renderable->getProperties();
@@ -177,9 +178,13 @@ list. A Form Element Renderer must implement the ``RendererInterface`` interface
 	         $content .= sprintf('<li>%s</li>', htmlspecialchars($item));
 	      }
 	      $content .= '</ul>';
+	      $content = $this->formRuntime->invokeRenderCallbacks($content, $renderable);
 	      return $content;
 	   }
 	}
+
+.. note::  Don't forget to invoke ``RootRenderableInterface::beforeRendering()`` and ``FormRuntime::invokeRenderCallbacks()``
+   as shown above.
 
 .. tip:: If you write your own Renderer make sure to sanitize values with ``htmlspecialchars()`` before outputting
    them to prevent invalid HTML and XSS vulnerabilities.


### PR DESCRIPTION
Adds an API method `registerRenderCallback()` to the `FormRuntime`
that allows for influencing the rendering of rendered elements.

Usage:

    $formRuntime->registerRenderCallback(function (string $output, RootRenderableInterface $renderable) {
        return $renderable->getIdentifier() . ': ' . $output;
    });

This simple example will render the Element identifier in front of every form
element, independantly from the configured Form (Element) Renderer.

Background:
The rendering of Form Elements can already be configured and altered
thoroughly, but this allows for 3rd party integration. For example we can
use this to wrap each Form Element using the `ContentElementWrappingService`
in order to render the required wraps in the Neos Backend.