### PR TITLE
FEATURE: EmailFinisher file attachments

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -16,6 +16,7 @@ use Neos\FluidAdaptor\View\StandaloneView;
 use Neos\Form\Core\Model\AbstractFinisher;
 use Neos\Form\Exception\FinisherException;
 use Neos\SwiftMailer\Message as SwiftMailerMessage;
+use Neos\Utility\ObjectAccess;
 
 /**
  * This finisher sends an email to one or more recipients
@@ -204,10 +205,7 @@ class EmailFinisher extends AbstractFinisher
             if (!isset($attachmentConfiguration['formElement'])) {
                 throw new FinisherException('The "attachments" options need to specify a "resource" path or a "formElement" containing the resource to attach', 1503396636);
             }
-            if (!isset($formValues[$attachmentConfiguration['formElement']])) {
-                continue;
-            }
-            $resource = $formValues[$attachmentConfiguration['formElement']];
+            $resource = ObjectAccess::getPropertyPath($formValues, $attachmentConfiguration['formElement']);
             if (!$resource instanceof PersistentResource) {
                 continue;
             }

--- a/Documentation/configuring-form-yaml.rst
+++ b/Documentation/configuring-form-yaml.rst
@@ -88,3 +88,60 @@ The following YAML is stored as ``contact.yaml``:
           senderAddress: '{email}'
           senderName: '{name}'
           format: plaintext
+
+
+File Uploads
+------------
+
+The ``default`` preset comes with an ``FileUpload`` form element that allows the user of the form to upload arbitrary
+files.
+With the latest version, the ``EmailFinisher`` allows these files to be sent as attachments:
+
+.. code-block:: yaml
+
+    type: 'Neos.Form:Form'
+    identifier: 'application'
+    label: 'Example application form'
+    renderables:
+      -
+        type: 'Neos.Form:Page'
+        identifier: 'page-one'
+        renderables:
+          -
+            type: 'Neos.Form:SingleLineText'
+            identifier: email
+            label: 'Email'
+            validators:
+              - identifier: 'Neos.Flow:NotEmpty'
+              - identifier: 'Neos.Flow:EmailAddress'
+          -
+            type: 'Neos.Form:FileUpload'
+            identifier: applicationform
+            label: 'Application Form (PDF)'
+            properties:
+              allowedExtensions:
+                - pdf
+            validators:
+              - identifier: 'Neos.Flow:NotEmpty'
+    finishers:
+      -
+        # Application email that is sent to "customer care" with all uploaded files attached
+        identifier: 'Neos.Form:Email'
+        options:
+          templatePathAndFilename: 'resource://AcmeCom.SomePackage/Private/Form/EmailTemplates/Application.html'
+          subject: 'New Application'
+          recipientAddress: 'application@acme.com'
+          senderAddress: '{email}'
+          format: html
+          attachAllPersistentResources: true
+      -
+        # Confirmation email that is sent to the user with a static file attachment
+        identifier: 'Neos.Form:Email'
+        options:
+          templatePathAndFilename: 'resource://AcmeCom.SomePackage/Private/Form/EmailTemplates/Confirmation.html'
+          subject: 'Your Application'
+          recipientAddress: '{email}'
+          senderAddress: 'application@acme.com'
+          format: html
+          attachments:
+            - resource: 'resource://AcmeCom.SomePackage/Private/Form/EmailTemplates/Attachments/TermsAndConditions.pdf'

--- a/Documentation/configuring-form-yaml.rst
+++ b/Documentation/configuring-form-yaml.rst
@@ -95,7 +95,7 @@ File Uploads
 
 The ``default`` preset comes with an ``FileUpload`` form element that allows the user of the form to upload arbitrary
 files.
-With the latest version, the ``EmailFinisher`` allows these files to be sent as attachments:
+The ``EmailFinisher`` allows these files to be sent as attachments:
 
 .. code-block:: yaml
 
@@ -145,3 +145,5 @@ With the latest version, the ``EmailFinisher`` allows these files to be sent as 
           format: html
           attachments:
             - resource: 'resource://AcmeCom.SomePackage/Private/Form/EmailTemplates/Attachments/TermsAndConditions.pdf'
+
+.. note:: attachments can also referenced via `formElement` paths explicitly, for example: ``- formElement: 'image-field.resource'``


### PR DESCRIPTION
Extends the `EmailFinisher` to be able to send files
(uploaded via the form or static ones) as attachment(s).

Usage:

```yaml
finishers:
  -
    identifier: 'Neos.Form:Email'
    options:
      # ...
      attachAllPersistentResources: true
```

This would attach files from all FormElements with dataType `PersistentResource` (e.g. the `FileUpload` element defined in the `default` preset)

```yaml
finishers:
  -
    identifier: 'Neos.Form:Email'
    options:
      # ...
      attachments:
        - resource: 'resource://Some.Vendor:Package/Some/Path/To/A/File'
        - formElement: 'some-upload-field'
```
This would attach a static file, referenced via the `resource` option and an uploaded
file (if the element `some-upload-field` exists in that form and contains a `PersistentResource`).

This change also improves the exception message that is thrown if the `Neos.SwiftMailer`
package is not installed.