### PR TITLE
BUGFIX: Fix `ImageUpload` FormElement rendering

### DIFF
--- a/Classes/ViewHelpers/Form/UploadedImageViewHelper.php
+++ b/Classes/ViewHelpers/Form/UploadedImageViewHelper.php
@@ -80,10 +80,10 @@ class UploadedImageViewHelper extends AbstractFormFieldViewHelper
         if ($this->getMappingResultsForProperty()->hasErrors()) {
             return null;
         }
-        $image = $this->getValue(false);
+        $image = $this->getPropertyValue();
         if ($image instanceof Image) {
             return $image;
         }
-        return $this->propertyMapper->convert($image, Image::class);
+        return $this->propertyMapper->convert($this->getValueAttribute(), Image::class);
     }
 }

--- a/Resources/Private/Form/ImageUpload.html
+++ b/Resources/Private/Form/ImageUpload.html
@@ -23,18 +23,16 @@
 		</f:if>
 		<script type="text/javascript">
 		//<![CDATA[
-			var resourcePointers = [];
 			function enableUpload(property) {
 				document.getElementById(property + '-preview').style.display = 'none';
 				document.getElementById(property + '-uploadfields').style.display = 'block';
-				resourcePointers[property] = document.getElementById(property + '-resourcePointer').value;
-				document.getElementById(property + '-resourcePointer').value = '';
+				document.getElementById(property + '-resource-identity').setAttribute('disabled', true);
 				return true;
 			}
 			function disableUpload(property) {
 				document.getElementById(property + '-preview').style.display = 'block';
 				document.getElementById(property + '-uploadfields').style.display = 'none';
-				document.getElementById(property + '-resourcePointer').value = resourcePointers[property];
+				document.getElementById(property + '-resource-identity').removeAttribute('disabled');
 				return true;
 			}
 		//]]></script>


### PR DESCRIPTION
Adjusts the Fluid Template for the `ImageUpload` field (and the corresponding
ViewHelper) to make the upload work again with latest Flow/Neos versions