### PR TITLE
FEATURE: Allow the EmailFinisher template source to be set

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -23,7 +23,8 @@ use Neos\Utility\ObjectAccess;
  *
  * Options:
  *
- * - templatePathAndFilename (mandatory): Template path and filename for the mail body
+ * - templatePathAndFilename (mandatory if "templateSource" option is not set): Template path and filename for the mail body
+ * - templateSource (mandatory if "templatePathAndFilename" option is not set): The raw Fluid template
  * - layoutRootPath: root path for the layouts
  * - partialRootPath: root path for the partials
  * - variables: associative array of variables which are available inside the Fluid template
@@ -163,10 +164,14 @@ class EmailFinisher extends AbstractFinisher
     protected function initializeStandaloneView()
     {
         $standaloneView = new StandaloneView();
-        if (!isset($this->options['templatePathAndFilename'])) {
-            throw new FinisherException('The option "templatePathAndFilename" must be set for the EmailFinisher.', 1327058829);
+        if (isset($this->options['templatePathAndFilename'])) {
+            $standaloneView->setTemplatePathAndFilename($this->options['templatePathAndFilename']);
+        } elseif (isset($this->options['templateSource'])) {
+            $standaloneView->setTemplateSource($this->options['templateSource']);
+        } else {
+            throw new FinisherException('The option "templatePathAndFilename" or "templateSource" must be set for the EmailFinisher.', 1327058829);
         }
-        $standaloneView->setTemplatePathAndFilename($this->options['templatePathAndFilename']);
+
 
         if (isset($this->options['partialRootPath'])) {
             $standaloneView->setPartialRootPath($this->options['partialRootPath']);
@@ -175,6 +180,8 @@ class EmailFinisher extends AbstractFinisher
         if (isset($this->options['layoutRootPath'])) {
             $standaloneView->setLayoutRootPath($this->options['layoutRootPath']);
         }
+
+        $standaloneView->assign('formValues', $this->finisherContext->getFormValues());
 
         if (isset($this->options['variables'])) {
             $standaloneView->assignMultiple($this->options['variables']);

--- a/Documentation/configuring-form-yaml.rst
+++ b/Documentation/configuring-form-yaml.rst
@@ -89,6 +89,9 @@ The following YAML is stored as ``contact.yaml``:
           senderName: '{name}'
           format: plaintext
 
+.. note:: Instead of setting the ``templatePathAndFilename`` option to specify the Fluid template file for the EmailFinisher,
+          the template source can also be set directly via the ``templateSource`` option.
+
 
 File Uploads
 ------------


### PR DESCRIPTION
This adds a new option `templateSource` to the `EmailFinisher`
that allows the Fluid template to be specified directly.

Besides this makes all submitted form values accessible within
the EmailFinisher template as `formValues`::

    finishers:
      -
        identifier: 'Neos.Form:Email'
        options:
          templateSource: 'Hello {formValues.name}, ...'