### PR TITLE
BUGFIX: Prevent fatal error when using the RenderViewHelper

### DIFF
--- a/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Classes/ViewHelpers/RenderViewHelper.php
@@ -49,10 +49,10 @@ class RenderViewHelper extends AbstractViewHelper
      * @param array $overrideConfiguration factory specific configuration
      * @return string the rendered form
      */
-    public function render($persistenceIdentifier = null, $factoryClass = \Neos\Form\Factory\ArrayFormFactory::class, $presetName = 'default', array $overrideConfiguration = null)
+    public function render($persistenceIdentifier = null, $factoryClass = \Neos\Form\Factory\ArrayFormFactory::class, $presetName = 'default', array $overrideConfiguration = [])
     {
         if (isset($persistenceIdentifier)) {
-            $overrideConfiguration = Arrays::arrayMergeRecursiveOverrule($this->formPersistenceManager->load($persistenceIdentifier), $overrideConfiguration ?: []);
+            $overrideConfiguration = Arrays::arrayMergeRecursiveOverrule($this->formPersistenceManager->load($persistenceIdentifier), $overrideConfiguration);
         }
 
         $factory = $this->objectManager->get($factoryClass);


### PR DESCRIPTION
When using the `RenderViewHelper` without specifying the `overrideConfiguration`
argument, a fatal error is thrown.
This patch prevents this by making the default value of the argument an empty
array.

Fixes: #7