### PR TITLE
BUGFIX: Remove wrong "Neos" in Settings.yaml

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -196,7 +196,6 @@ Neos:
             implementationClassName: Neos\Flow\Validation\Validator\RegularExpressionValidator
           'Neos.Flow:Count':
             implementationClassName: Neos\Flow\Validation\Validator\CountValidator
-Neos:
   DocTools:
     bundles:
       Form:


### PR DESCRIPTION
It is a wrong Neos in the Settings.yaml which overwrites the configuration above.