### PR TITLE
Option parsing of arrays and form values in the ConfirmationFinisher

### DIFF
--- a/Classes/Core/Model/AbstractFinisher.php
+++ b/Classes/Core/Model/AbstractFinisher.php
@@ -11,6 +11,7 @@ namespace Neos\Form\Core\Model;
  * source code.
  */
 
+use Neos\Utility\Arrays;
 use Neos\Utility\ObjectAccess;
 
 /**
@@ -104,7 +105,11 @@ abstract class AbstractFinisher implements FinisherInterface
     protected function parseOption($optionName)
     {
         if (!isset($this->options[$optionName]) || $this->options[$optionName] === '') {
-            if (isset($this->defaultOptions[$optionName])) {
+            if (!is_null(Arrays::getValueByPath($this->options, $optionName)) && Arrays::getValueByPath($this->options, $optionName) !== '') {
+                $option = Arrays::getValueByPath($this->options, $optionName);
+            } else if (!is_null(Arrays::getValueByPath($this->defaultOptions, $optionName)) && Arrays::getValueByPath($this->defaultOptions, $optionName) !== '') {
+                $option = Arrays::getValueByPath($this->defaultOptions, $optionName);
+            } else if (isset($this->defaultOptions[$optionName])) {
                 $option = $this->defaultOptions[$optionName];
             } else {
                 return null;

--- a/Classes/Finishers/ConfirmationFinisher.php
+++ b/Classes/Finishers/ConfirmationFinisher.php
@@ -87,7 +87,7 @@ class ConfirmationFinisher extends AbstractFinisher
                 $renderingOptions = $formRuntime->getRenderingOptions();
                 $messagePackageKey = $renderingOptions['translationPackage'];
             }
-            $message = $this->translator->translateById($labelId, [], null, $locale, $this->parseOption('translation.source'), $messagePackageKey);
+            $message = $this->translator->translateById($labelId, $this->finisherContext->getFormValues(), null, $locale, $this->parseOption('translation.source'), $messagePackageKey);
         } else {
             $message = $this->parseOption('message');
         }


### PR DESCRIPTION
Allow option parsing of arrays (translation.* in neos/form-builder prototypes) and make form values available for the translation.