### PR TITLE
BUGFIX: Evaluate attachment configuration only if present

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -213,9 +213,9 @@ class EmailFinisher extends AbstractFinisher
                 }
             }
         }
-
-        if ($this->parseOption('attachments')) {
-            foreach ($this->parseOption('attachments') as $attachmentConfiguration) {
+        $attachmentConfigurations = $this->parseOption('attachments');
+        if (is_array($attachmentConfigurations)) {
+            foreach ($attachmentConfigurations as $attachmentConfiguration) {
                 if (isset($attachmentConfiguration['resource'])) {
                     $mail->attach(\Swift_Attachment::fromPath($attachmentConfiguration['resource']));
                     continue;


### PR DESCRIPTION
The addAttachment ran into trouble when it tired to iterate over en attachments configuration that was not set at all. The change adds a beforehand check that the attachments configuration is set.