### PR TITLE
TASK: Allow the configuration of the form type

### DIFF
--- a/Classes/Factory/ArrayFormFactory.php
+++ b/Classes/Factory/ArrayFormFactory.php
@@ -36,7 +36,7 @@ class ArrayFormFactory extends AbstractFormFactory
     {
         $formDefaults = $this->getPresetConfiguration($presetName);
 
-        $form = new FormDefinition($configuration['identifier'], $formDefaults);
+        $form = new FormDefinition($configuration['identifier'], $formDefaults, $configuration['type'] ?? null);
         if (isset($configuration['renderables'])) {
             foreach ($configuration['renderables'] as $pageConfiguration) {
                 $this->addNestedRenderable($pageConfiguration, $form);


### PR DESCRIPTION
For the creation of atomic rendered forms in the upcoming package https://github.com/1drop/Onedrop.Form.Hubspot i need to override the default `neos:Form:Form` form type with my own form type. To achieve this the configuration of the form should be usable.

Background: With the `ArrayFormFactory` i can create forms by defining them as an array. I can control the type of any created sub element (renderable) by passing `type` in the configuration for that element. The only place where this is currently not possible is the root element (the `FormDefinition`). Therefor i chose to read the type from the configuration array.

This does not change any signature, so it is not a BC but fully backwards compatible.