### PR TITLE
BUGFIX: Don't ignore response headers when rendering a form

### DIFF
--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -338,6 +338,12 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
     {
         if ($this->isAfterLastPage()) {
             $this->invokeFinishers();
+            $parentResponse = $this->response->getParentResponse();
+            if ($parentResponse !== null) {
+                foreach ($this->response->getHeaders()->getAll() as $key => $value) {
+                    $parentResponse->getHeaders()->set($key, $value, true);
+                }
+            }
             return $this->response->getContent();
         }
 


### PR DESCRIPTION
This fixes `FormRuntime::render()` to bubble up response
headers to the parent response.

This will make sure that any headers that have been set by
finishers (e.g. the `Location`-header in the `RedirectFinisher`)
are actually taken into account.

Fixes: #84