### PR TITLE
FEATURE: send multipart mail with EmailFinisher

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -167,7 +167,7 @@ class EmailFinisher extends AbstractFinisher
         }
     }
 
-    protected function addMessages(SwiftMailerMessage $mail, $messages): void
+    protected function addMessages(SwiftMailerMessage $mail, array $messages): void
     {
         foreach ($messages as $messageFormat => $message) {
             if (count($messages) === 1) {

--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -184,7 +184,7 @@ class EmailFinisher extends AbstractFinisher
         if ($format === self::FORMAT_MULTIPART) {
             $messages[self::FORMAT_HTML] = $this->createMessage(self::FORMAT_HTML);
             $messages[self::FORMAT_PLAINTEXT] = $this->createMessage(self::FORMAT_PLAINTEXT);
-        } else if ($format === self::FORMAT_PLAINTEXT) {
+        } elseif ($format === self::FORMAT_PLAINTEXT) {
             $messages[self::FORMAT_PLAINTEXT] = $this->createMessage(self::FORMAT_PLAINTEXT);
         } else {
             $messages[self::FORMAT_HTML] = $this->createMessage(self::FORMAT_HTML);


### PR DESCRIPTION
At the moment it is not possible to send multipart mails with the EmailFinisher.
This PR adds 4 new options:
* htmlTemplatePathAndFilename
* htmlTemplateSource
* plaintextTemplatePathAndFilename
* plaintextTemplateSource

A new format constant `FORMAT_MULTIPART` is introduced.

Example form config:

```yaml
type: 'Neos.Form:Form'
identifier: 'contact'
label: 'Contact form'
renderables:
  -
    type: 'Neos.Form:Page'
    identifier: 'page-one'
    renderables:
      ...
finishers:
  -
    identifier: 'Neos.Form:Email'
    options:
      plaintextTemplatePathAndFilename: resource://AcmeCom.SomePackage/Private/Templates/Form/Contact.txt
      htmlTemplatePathAndFilename: resource://AcmeCom.SomePackage/Private/Templates/Form/Contact.html
      subject: '{subject}'
      recipientAddress: 'info@acme.com'
      recipientName: 'Acme Customer Care'
      senderAddress: '{email}'
      senderName: '{name}'
      format: multipart
```

Resolves: #116