### PR TITLE
TASK: Remove arguments from VH render methods

### DIFF
--- a/Classes/ViewHelpers/Form/DatePickerViewHelper.php
+++ b/Classes/ViewHelpers/Form/DatePickerViewHelper.php
@@ -48,23 +48,26 @@ class DatePickerViewHelper extends AbstractFormFieldViewHelper
         $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this view helper', false, 'f3-form-error');
         $this->registerArgument('initialDate', 'string', 'Initial date (@see http://www.php.net/manual/en/datetime.formats.php for supported formats)');
         $this->registerUniversalTagAttributes();
+
+        $this->registerArgument('dateFormat', 'string', 'Format to use for date formatting', false, 'Y-m-d');
+        $this->registerArgument('enableDatePicker', 'boolean', 'true to enable a date picker', false, true);
     }
 
     /**
      * Renders the text field, hidden field and required javascript
      *
-     * @param string $dateFormat
-     * @param boolean $enableDatePicker
      * @return string
+     * @throws \Exception
      */
-    public function render($dateFormat = 'Y-m-d', $enableDatePicker = true)
+    public function render(): string
     {
         $name = $this->getName();
+        $dateFormat = $this->arguments['dateFormat'];
         $this->registerFieldNameForFormTokenGeneration($name);
 
         $this->tag->addAttribute('type', 'date');
         $this->tag->addAttribute('name', $name . '[date]');
-        if ($enableDatePicker) {
+        if ($this->arguments['enableDatePicker']) {
             $this->tag->addAttribute('readonly', true);
         }
         $date = $this->getSelectedDate();
@@ -83,21 +86,21 @@ class DatePickerViewHelper extends AbstractFormFieldViewHelper
         $content .= $this->tag->render();
         $content .= '<input type="hidden" name="' . $name . '[dateFormat]" value="' . htmlspecialchars($dateFormat) . '" />';
 
-        if ($enableDatePicker) {
+        if ($this->arguments['enableDatePicker']) {
             $datePickerDateFormat = $this->convertDateFormatToDatePickerFormat($dateFormat);
             $content .= '<script type="text/javascript">//<![CDATA[
-				$(function() {
-					$("#' . $id . '").datepicker({
-						dateFormat: "' . $datePickerDateFormat . '"
-					}).keydown(function(e) {
-							// By using "backspace" or "delete", you can clear the datepicker again.
-						if(e.keyCode == 8 || e.keyCode == 46) {
-							e.preventDefault();
-							$.datepicker._clearDate(this);
-						}
-					});
-				});
-				//]]></script>';
+                $(function() {
+                    $("#' . $id . '").datepicker({
+                        dateFormat: "' . $datePickerDateFormat . '"
+                    }).keydown(function(e) {
+                            // By using "backspace" or "delete", you can clear the datepicker again.
+                        if(e.keyCode == 8 || e.keyCode == 46) {
+                            e.preventDefault();
+                            $.datepicker._clearDate(this);
+                        }
+                    });
+                });
+                //]]></script>';
         }
         return $content;
     }
@@ -105,7 +108,7 @@ class DatePickerViewHelper extends AbstractFormFieldViewHelper
     /**
      * @return \DateTime|null
      */
-    protected function getSelectedDate()
+    protected function getSelectedDate(): ?\DateTime
     {
         $date = $this->getPropertyValue();
         if ($date instanceof \DateTime) {
@@ -128,7 +131,7 @@ class DatePickerViewHelper extends AbstractFormFieldViewHelper
      * @param string $dateFormat
      * @return string
      */
-    protected function convertDateFormatToDatePickerFormat($dateFormat)
+    protected function convertDateFormatToDatePickerFormat(string $dateFormat): string
     {
         $replacements = array(
             'd' => 'dd',

--- a/Classes/ViewHelpers/Form/FormElementRootlinePathViewHelper.php
+++ b/Classes/ViewHelpers/Form/FormElementRootlinePathViewHelper.php
@@ -20,11 +20,24 @@ use Neos\Form\Core\Model\Renderable\RenderableInterface;
 class FormElementRootlinePathViewHelper extends AbstractViewHelper
 {
     /**
-     * @param RenderableInterface $renderable
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('renderable', RenderableInterface::class, 'The renderable', true);
+    }
+
+    /**
      * @return string
      */
-    public function render(RenderableInterface $renderable)
+    public function render()
     {
+        /** @var RenderableInterface $renderable */
+        $renderable = $this->arguments['renderable'];
         $path = $renderable->getIdentifier();
         while ($renderable = $renderable->getParentRenderable()) {
             $path = $renderable->getIdentifier() . '/' . $path;

--- a/Classes/ViewHelpers/Form/UploadedImageViewHelper.php
+++ b/Classes/ViewHelpers/Form/UploadedImageViewHelper.php
@@ -46,21 +46,22 @@ class UploadedImageViewHelper extends AbstractFormFieldViewHelper
      * Initialize the arguments.
      *
      * @return void
-     * @author Sebastian Kurfürst <sebastian@typo3.org>
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      * @api
      */
     public function initializeArguments()
     {
         parent::initializeArguments();
+        $this->registerArgument('as', 'string', 'Variable name to use for the uploaded image', false, 'image');
     }
 
     /**
-     * @param string $as
      * @return string
      * @api
      */
-    public function render($as = 'image')
+    public function render(): string
     {
+        $as = $this->arguments['as'];
         $this->templateVariableContainer->add($as, $this->getUploadedImage());
         $output = $this->renderChildren();
         $this->templateVariableContainer->remove($as);
@@ -73,8 +74,10 @@ class UploadedImageViewHelper extends AbstractFormFieldViewHelper
      * If errors occurred during property mapping for this property, NULL is returned
      *
      * @return Image
+     * @throws \Neos\Flow\Property\Exception
+     * @throws \Neos\Flow\Security\Exception
      */
-    protected function getUploadedImage()
+    protected function getUploadedImage(): Image
     {
         if ($this->getMappingResultsForProperty()->hasErrors()) {
             return null;

--- a/Classes/ViewHelpers/Form/UploadedResourceViewHelper.php
+++ b/Classes/ViewHelpers/Form/UploadedResourceViewHelper.php
@@ -48,22 +48,24 @@ class UploadedResourceViewHelper extends AbstractFormFieldViewHelper
      * Initialize the arguments.
      *
      * @return void
-     * @author Sebastian Kurfürst <sebastian@typo3.org>
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      * @api
      */
     public function initializeArguments()
     {
         parent::initializeArguments();
+        $this->registerArgument('as', 'string', 'Variable name to use for the uploaded resource', false, 'resource');
     }
 
     /**
-     * @param string $as
      * @return string
-     * @author Sebastian Kurfürst <sebastian@typo3.org>
+     * @throws \Neos\Flow\Property\Exception
+     * @throws \Neos\Flow\Security\Exception
      * @api
      */
-    public function render($as = 'resource')
+    public function render(): string
     {
+        $as = $this->arguments['as'];
         $this->templateVariableContainer->add($as, $this->getUploadedResource());
         $output = $this->renderChildren();
         $this->templateVariableContainer->remove($as);
@@ -76,8 +78,10 @@ class UploadedResourceViewHelper extends AbstractFormFieldViewHelper
      * If errors occurred during property mapping for this property, NULL is returned
      *
      * @return PersistentResource
+     * @throws \Neos\Flow\Property\Exception
+     * @throws \Neos\Flow\Security\Exception
      */
-    protected function getUploadedResource()
+    protected function getUploadedResource(): PersistentResource
     {
         if ($this->getMappingResultsForProperty()->hasErrors()) {
             return null;

--- a/Classes/ViewHelpers/RenderHeadViewHelper.php
+++ b/Classes/ViewHelpers/RenderHeadViewHelper.php
@@ -39,18 +39,30 @@ class RenderHeadViewHelper extends AbstractViewHelper
     protected $formBuilderFactory;
 
     /**
-     * @param string $presetName name of the preset to use
-     * @return string the rendered form head
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
-    public function render($presetName = 'default')
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('presetName', 'string', 'Relative Fusion path to be rendered', false, ' default');
+    }
+
+    /**
+     * @return string the rendered form head
+     * @throws \Neos\Form\Exception\PresetNotFoundException
+     */
+    public function render(): string
     {
         $content = '';
-        $presetConfiguration = $this->formBuilderFactory->getPresetConfiguration($presetName);
-        $stylesheets = isset($presetConfiguration['stylesheets']) ? $presetConfiguration['stylesheets'] : [];
+        $presetConfiguration = $this->formBuilderFactory->getPresetConfiguration($this->arguments['presetName']);
+        $stylesheets = $presetConfiguration['stylesheets'] ?? [];
         foreach ($stylesheets as $stylesheet) {
             $content .= sprintf('<link href="%s" rel="stylesheet">', $this->resourceManager->getPublicPackageResourceUriByPath($stylesheet['source']));
         }
-        $javaScripts = isset($presetConfiguration['javaScripts']) ? $presetConfiguration['javaScripts'] : [];
+        $javaScripts = $presetConfiguration['javaScripts'] ?? [];
         foreach ($javaScripts as $javaScript) {
             $content .= sprintf('<script src="%s"></script>', $this->resourceManager->getPublicPackageResourceUriByPath($javaScript['source']));
         }

--- a/Classes/ViewHelpers/RenderRenderableViewHelper.php
+++ b/Classes/ViewHelpers/RenderRenderableViewHelper.php
@@ -26,13 +26,24 @@ class RenderRenderableViewHelper extends AbstractViewHelper
     protected $escapeOutput = false;
 
     /**
-     * @param RenderableInterface $renderable
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('renderable', RenderableInterface::class, '', true);
+    }
+
+    /**
      * @return string
      */
-    public function render(RenderableInterface $renderable)
+    public function render(): string
     {
         /** @var RendererInterface $view */
         $view = $this->viewHelperVariableContainer->getView();
-        return $view->renderRenderable($renderable);
+        return $view->renderRenderable($this->arguments['renderable']);
     }
 }

--- a/Classes/ViewHelpers/TranslateElementPropertyViewHelper.php
+++ b/Classes/ViewHelpers/TranslateElementPropertyViewHelper.php
@@ -44,15 +44,27 @@ class TranslateElementPropertyViewHelper extends AbstractViewHelper
     protected $escapeChildren = false;
 
     /**
-     * @param string $property
-     * @param FormElementInterface $element
+     * Initialize the arguments.
+     *
+     * @return void
+     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('property', 'string', 'The property to translate', true);
+        $this->registerArgument('element', FormElementInterface::class, 'Form element');
+    }
+
+    /**
      * @return string the rendered form head
      */
-    public function render($property, FormElementInterface $element = null)
+    public function render(): string
     {
-        if ($element === null) {
+        if (!$this->hasArgument('element')) {
             $element = $this->renderChildren();
         }
+        $property = $this->arguments['property'];
         if ($property === 'label') {
             $defaultValue = $element->getLabel();
         } else {
@@ -68,6 +80,6 @@ class TranslateElementPropertyViewHelper extends AbstractViewHelper
         } catch (ResourceException $exception) {
             return $defaultValue;
         }
-        return $translation === null ? $defaultValue : $translation;
+        return $translation ?? $defaultValue;
     }
 }

--- a/Tests/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/AbstractFunctionalTestCase.php
@@ -12,6 +12,7 @@ namespace Neos\Form\Tests\Functional;
  */
 
 use Neos\Flow\Http\Client\Browser;
+use Neos\Flow\Http\Response as HttpResponse;
 use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Symfony\Component\DomCrawler\Field\InputFormField;
@@ -53,9 +54,9 @@ abstract class AbstractFunctionalTestCase extends FunctionalTestCase
      * Go to the next form page
      *
      * @param Form $form
-     * @return \Neos\Flow\Http\Response
+     * @return HttpResponse
      */
-    protected function gotoNextFormPage(Form $form)
+    protected function gotoNextFormPage(Form $form): HttpResponse
     {
         $nextButton = $this->browser->getCrawler()->filterXPath('//nav[@class="form-navigation"]/*/*[contains(@class, "next")]/button');
         /** @var \DOMElement $node */
@@ -69,9 +70,9 @@ abstract class AbstractFunctionalTestCase extends FunctionalTestCase
      * Go to the previous form page
      *
      * @param Form $form
-     * @return \Neos\Flow\Http\Response
+     * @return HttpResponse
      */
-    protected function gotoPreviousFormPage(Form $form)
+    protected function gotoPreviousFormPage(Form $form): HttpResponse
     {
         $previousButton = $this->browser->getCrawler()->filterXPath('//nav[@class="form-navigation"]/*/*[contains(@class, "previous")]/button');
         /** @var \DOMElement $node */


### PR DESCRIPTION
This removes the arguments from `render()` in Fluid ViewHelpers, and
registers them using `registerArgument` instead.

Arguments to `render()` were deprecated as of Flow 4.0 and support
is removed with Flow 6.0.