### PR TITLE
Bugfix: Do not inject prototype scoped objects

### DIFF
--- a/Classes/Core/Model/ProcessingRule.php
+++ b/Classes/Core/Model/ProcessingRule.php
@@ -30,13 +30,11 @@ class ProcessingRule
     protected $dataType;
 
     /**
-     * @Flow\Inject
      * @var \Neos\Flow\Property\PropertyMappingConfiguration
      */
     protected $propertyMappingConfiguration;
 
     /**
-     * @Flow\Inject
      * @var \Neos\Flow\Validation\Validator\ConjunctionValidator
      */
     protected $validator;
@@ -58,6 +56,8 @@ class ProcessingRule
      */
     public function __construct()
     {
+        $this->propertyMappingConfiguration = new \Neos\Flow\Property\PropertyMappingConfiguration();
+        $this->validator = new \Neos\Flow\Validation\Validator\ConjunctionValidator();
         $this->processingMessages = new Result();
     }
 

--- a/Tests/Unit/Core/Model/ProcessingRuleTest.php
+++ b/Tests/Unit/Core/Model/ProcessingRuleTest.php
@@ -39,13 +39,10 @@ class ProcessingRuleTest extends UnitTestCase
     public function setUp()
     {
         $this->mockPropertyMapper = $this->getMockBuilder(PropertyMapper::class)->getMock();
-        $this->processingRule = $this->getAccessibleMock(ProcessingRule::class, array('dummy'));
-        /** @noinspection PhpUndefinedMethodInspection */
-        $this->processingRule->_set('propertyMapper', $this->mockPropertyMapper);
-        /** @noinspection PhpUndefinedMethodInspection */
-        $this->processingRule->_set('validator', new ConjunctionValidator());
-        /** @noinspection PhpUndefinedMethodInspection */
-        $this->processingRule->_set('processingMessages', new Result());
+
+        $this->processingRule = new ProcessingRule();
+
+        $this->inject($this->processingRule, 'propertyMapper', $this->mockPropertyMapper);
     }
 
     /**
@@ -124,11 +121,9 @@ class ProcessingRuleTest extends UnitTestCase
     public function processConvertsValueIfDataTypeIsSpecified()
     {
         $this->processingRule->setDataType('SomeDataType');
-        $mockPropertyMappingConfiguration = $this->getMockBuilder(PropertyMappingConfiguration::class)->getMock();
-        /** @noinspection PhpUndefinedMethodInspection */
-        $this->processingRule->_set('propertyMappingConfiguration', $mockPropertyMappingConfiguration);
+        $propertyMappingConfiguration = $this->processingRule->getPropertyMappingConfiguration();
 
-        $this->mockPropertyMapper->expects($this->once())->method('convert')->with('Some Value', 'SomeDataType', $mockPropertyMappingConfiguration)->will($this->returnValue('Converted Value'));
+        $this->mockPropertyMapper->expects($this->once())->method('convert')->with('Some Value', 'SomeDataType', $propertyMappingConfiguration)->will($this->returnValue('Converted Value'));
         $this->mockPropertyMapper->expects($this->any())->method('getMessages')->will($this->returnValue(new Result()));
         $this->assertEquals('Converted Value', $this->processingRule->process('Some Value'));
     }


### PR DESCRIPTION
Injecting prototype scoped objects prevents deserialization and thus
caching of a form definition (which is helpful with larger node based
forms).

Closes #94