### PR TITLE
BUGFIX: Double slashes after base uri

### DIFF
--- a/Classes/Finishers/RedirectFinisher.php
+++ b/Classes/Finishers/RedirectFinisher.php
@@ -55,7 +55,11 @@ class RedirectFinisher extends AbstractFinisher
 
         $uriParts = parse_url($uri);
         if (!isset($uriParts['scheme']) || $uriParts['scheme'] === '') {
-            $uri = $request->getHttpRequest()->getBaseUri() . $uri;
+            $baseUri = $request->getHttpRequest()->getBaseUri();
+            if (substr($baseUri, -1) === '/') {
+                $uri = ltrim($uri, '/');
+            }
+            $uri = $baseUri . $uri;
         }
 
         $escapedUri = htmlentities($uri, ENT_QUOTES, 'utf-8');

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -11,6 +11,8 @@ namespace Neos\Form\ViewHelpers;
  * source code.
  */
 
+use Neos\Flow\Http\Request;
+use Neos\Flow\Http\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\FluidAdaptor\ViewHelpers\FormViewHelper as FluidFormViewHelper;
 use Neos\Form\Core\Runtime\FormRuntime;
@@ -58,8 +60,14 @@ class FormViewHelper extends FluidFormViewHelper
     protected function getFormActionUri()
     {
         /** @var ActionRequest $actionRequest */
-        $actionRequest = $this->controllerContext->getRequest();
-        $uri = $actionRequest->getHttpRequest()->getUri();
+        $actionRequest = clone $this->controllerContext->getRequest();
+        $requestUri = $actionRequest->getHttpRequest()->getUri();
+        /** @var Uri $uri */
+        $uri = $actionRequest->getHttpRequest()->getAttribute(Request::ATTRIBUTE_BASE_URI)
+            ->withPath($requestUri->getPath())
+            ->withQuery($requestUri->getQuery())
+            ->withFragment($requestUri->getFragment());
+
         if ($this->hasArgument('section')) {
             $uri = preg_replace('/#.*$/', '', $uri) . '#' . $this->arguments['section'];
         }


### PR DESCRIPTION
In case the base uri ends with a slash and the uri parameter starts with a slash, we get double slashes. This even happens when the url is generated by `buildActionUri()` of this class.