### PR TITLE
FEATURE: Adds support for swiftmailer >= v6.0

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -217,7 +217,7 @@ class EmailFinisher extends AbstractFinisher
         if (is_array($attachmentConfigurations)) {
             foreach ($attachmentConfigurations as $attachmentConfiguration) {
                 if (isset($attachmentConfiguration['resource'])) {
-                    $mail->attach(\Swift_Attachment::fromPath($attachmentConfiguration['resource']));
+                    $mail->attach(new \Swift_Attachment($attachmentConfiguration['resource']));
                     continue;
                 }
                 if (!isset($attachmentConfiguration['formElement'])) {
@@ -227,7 +227,7 @@ class EmailFinisher extends AbstractFinisher
                 if (!$resource instanceof PersistentResource) {
                     continue;
                 }
-                $mail->attach(\Swift_Attachment::newInstance(stream_get_contents($resource->getStream()), $resource->getFilename(), $resource->getMediaType()));
+                $mail->attach(new \Swift_Attachment(stream_get_contents($resource->getStream()), $resource->getFilename(), $resource->getMediaType()));
             }
         }
     }

--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -209,7 +209,7 @@ class EmailFinisher extends AbstractFinisher
         if ($this->parseOption('attachAllPersistentResources')) {
             foreach ($formValues as $formValue) {
                 if ($formValue instanceof PersistentResource) {
-                    $mail->attach(\Swift_Attachment::newInstance(stream_get_contents($formValue->getStream()), $formValue->getFilename(), $formValue->getMediaType()));
+                    $mail->attach(new \Swift_Attachment(stream_get_contents($formValue->getStream()), $formValue->getFilename(), $formValue->getMediaType()));
                 }
             }
         }
@@ -217,7 +217,7 @@ class EmailFinisher extends AbstractFinisher
         if (is_array($attachmentConfigurations)) {
             foreach ($attachmentConfigurations as $attachmentConfiguration) {
                 if (isset($attachmentConfiguration['resource'])) {
-                    $mail->attach(new \Swift_Attachment($attachmentConfiguration['resource']));
+                    $mail->attach(\Swift_Attachment::fromPath($attachmentConfiguration['resource']));
                     continue;
                 }
                 if (!isset($attachmentConfiguration['formElement'])) {


### PR DESCRIPTION
Starting with version 6.0 Swiftmailer [removed newInstance() methods everywhere](https://github.com/swiftmailer/swiftmailer/blob/74e20ce4dad5011fb2c2cedefb76b2237f123c0e/CHANGES#L14).

This change reflects this change to support Swiftmailer >= v6.