### PR TITLE
BUGFIX: Double slashes after base uri

### DIFF
--- a/Classes/Finishers/RedirectFinisher.php
+++ b/Classes/Finishers/RedirectFinisher.php
@@ -65,7 +65,11 @@ class RedirectFinisher extends AbstractFinisher
 
         $uriParts = parse_url($uri);
         if (!isset($uriParts['scheme']) || $uriParts['scheme'] === '') {
-            $uri = $request->getHttpRequest()->getAttribute(ServerRequestAttributes::BASE_URI) . $uri;
+            $baseUri = $request->getHttpRequest()->getAttribute(ServerRequestAttributes::BASE_URI);
+            if (substr($baseUri, -1) === '/') {
+                $uri = ltrim($uri, '/');
+            }
+            $uri = $baseUri . $uri;
         }
 
         $escapedUri = htmlentities($uri, ENT_QUOTES, 'utf-8');


### PR DESCRIPTION
In case the base uri ends with a slash and the uri parameter starts with a slash, we get double slashes. This even happens when the url is generated by buildActionUri() of this class.

Original request here: #96

Closes #89 