### PR TITLE
!!! TASK: Use configured baseUri in form action

### DIFF
--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -73,9 +73,6 @@ class FormViewHelper extends FluidFormViewHelper
             ->withPath($requestUri->getPath())
             ->withQuery($requestUri->getQuery())
             ->withFragment($this->hasArgument('section') ? $this->arguments['section'] : $requestUri->getFragment());
-
-        if ($this->hasArgument('section')) {
-            $uri = preg_replace('/#.*$/', '', $uri) . '#' . $this->arguments['section'];
         }
         return (string)$uri;
     }

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -67,12 +67,12 @@ class FormViewHelper extends FluidFormViewHelper
     protected function getFormActionUri()
     {
         /** @var ActionRequest $actionRequest */
-        $actionRequest = clone $this->controllerContext->getRequest();
-        $requestUri = $actionRequest->getHttpRequest()->getUri();
-        $uri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest()
+        $httpRequest = $this->controllerContext->getRequest()->getHttpRequest();
+        $requestUri = $httpRequest->getUri();
+        $uri = $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest($httpRequest)
             ->withPath($requestUri->getPath())
             ->withQuery($requestUri->getQuery())
-            ->withFragment($requestUri->getFragment());
+            ->withFragment($this->hasArgument('section') ? $this->arguments['section'] : $requestUri->getFragment());
 
         if ($this->hasArgument('section')) {
             $uri = preg_replace('/#.*$/', '', $uri) . '#' . $this->arguments['section'];

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -73,7 +73,6 @@ class FormViewHelper extends FluidFormViewHelper
             ->withPath($requestUri->getPath())
             ->withQuery($requestUri->getQuery())
             ->withFragment($this->hasArgument('section') ? $this->arguments['section'] : $requestUri->getFragment());
-        }
         return (string)$uri;
     }
 }


### PR DESCRIPTION
`$actionRequest->getHttpRequest()->getUri()` returns the original request Uri, which conflicts if the Setting `Neos.Flow.http.baseUri` is overwritten.

TBH: I'm not sure if this is really the best way to replace the base uri, so I'm happy for any feedback.

Closes #22 