### PR TITLE
BUGFIX: Message constructor needs title to be string

### DIFF
--- a/Classes/Finishers/FlashMessageFinisher.php
+++ b/Classes/Finishers/FlashMessageFinisher.php
@@ -76,7 +76,7 @@ class FlashMessageFinisher extends AbstractFinisher
         if (!is_string($messageBody)) {
             throw new FinisherException(sprintf('The message body must be of type string, "%s" given.', gettype($messageBody)), 1335980069);
         }
-        $messageTitle = $this->parseOption('messageTitle');
+        $messageTitle = $this->parseOption('messageTitle') ?? '';
         $messageArguments = $this->parseOption('messageArguments');
         $messageCode = $this->parseOption('messageCode');
         $severity = $this->parseOption('severity');


### PR DESCRIPTION
`parseOption()` unfortunately returns `null` if the option value is an empty string.

Since 6.0, `Message` doesn't accept `null` values for the title argument anymore.