### PR TITLE
TASK: Adjust test to StringLengthValidator change

### DIFF
--- a/Tests/Unit/Core/Model/PageTest.php
+++ b/Tests/Unit/Core/Model/PageTest.php
@@ -373,7 +373,9 @@ class PageTest extends UnitTestCase
         $firstValidator = $validators[0];
         Assert::assertSame(2, count($validators));
         $this->assertInstanceOf(StringLengthValidator::class, $firstValidator);
-        Assert::assertSame(['minimum' => 10, 'maximum' => PHP_INT_MAX], $firstValidator->getOptions());
+        $validatorOptions = $firstValidator->getOptions();
+        Assert::assertSame($validatorOptions['minimum'], 10);
+        Assert::assertSame($validatorOptions['maximum'], PHP_INT_MAX);
     }
 
     /**


### PR DESCRIPTION
Test would fail due to unexpected validator option `"ignoreHtml"`.
See https://github.com/neos/flow-development-collection/pull/1849