### PR TITLE
FEATURE: Configurable Resource Collection for file uploads

### DIFF
--- a/Classes/FormElements/FileUpload.php
+++ b/Classes/FormElements/FileUpload.php
@@ -11,9 +11,13 @@ namespace Neos\Form\FormElements;
  * source code.
  */
 
+use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Flow\ResourceManagement\ResourceTypeConverter;
+use Neos\Flow\Validation\Exception\InvalidValidationOptionsException;
 use Neos\Form\Core\Model\AbstractFormElement;
 use Neos\Form\Core\Runtime\FormRuntime;
+use Neos\Form\Exception\FormDefinitionConsistencyException;
 use Neos\Form\Validation\FileTypeValidator;
 
 /**
@@ -35,9 +39,15 @@ class FileUpload extends AbstractFormElement
      * @param FormRuntime $formRuntime
      * @param mixed $elementValue
      * @return void
+     * @throws InvalidValidationOptionsException | FormDefinitionConsistencyException
      */
     public function onSubmit(FormRuntime $formRuntime, &$elementValue)
     {
+        if (isset($this->properties['resourceCollection'])) {
+            /** @var PropertyMappingConfiguration $propertyMappingConfiguration */
+            $propertyMappingConfiguration = $this->getRootForm()->getProcessingRule($this->getIdentifier())->getPropertyMappingConfiguration();
+            $propertyMappingConfiguration->setTypeConverterOption(ResourceTypeConverter::class, ResourceTypeConverter::CONFIGURATION_COLLECTION_NAME, $this->properties['resourceCollection']);
+        }
         $fileTypeValidator = new FileTypeValidator(array('allowedExtensions' => $this->properties['allowedExtensions']));
         $this->addValidator($fileTypeValidator);
     }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -137,6 +137,10 @@ Neos:
               'Neos.Form:FormElement': true
             implementationClassName: Neos\Form\FormElements\FileUpload
             properties:
+              # target collection of the uploaded PersistentResource
+              resourceCollection: 'persistent'
+              # set this to "false" if you don't want to create a link to the uploaded file (required for non-public resource collections)
+              createLinkToFilePreview: true
               allowedExtensions:
                 - pdf
                 - doc

--- a/Resources/Private/Form/FileUpload.html
+++ b/Resources/Private/Form/FileUpload.html
@@ -12,9 +12,11 @@
 		</div>
 		<f:if condition="{resource}">
 			<div id="{element.uniqueIdentifier}-preview">
-				<a href="{f:uri.resource(resource: resource)}">
-					{resource.filename}
-				</a>
+				<f:if condition="{element.properties.createLinkToFilePreview}" else="{resource.filename}">
+					<a href="{f:uri.resource(resource: resource)}">
+						{resource.filename}
+					</a>
+				</f:if>
 				<div class="clearfix">
 					<a class="btn small" href="#" onclick="return !enableUpload('{element.uniqueIdentifier}')"><f:translate id="forms.labels.replaceFile" package="{element.renderingOptions.translationPackage}">Replace File</f:translate></a>
 				</div>


### PR DESCRIPTION
This feature extends the `FileUpload` Form element such that
the target Resource Collection can be configured.

This can be useful for example in order to prevent uploaded
files to end up in the public "persistent" collection:

    Neos:
      Flow:
        resource:
          targets:
            'formUploadTarget':
              target: 'Some\Package\SomeProtectedResourceTarget'
          collections:
            'formUploads':
              storage: 'defaultPersistentResourcesStorage'
              target: 'formUploadTarget'
      Form:
        presets:
          'default':
            formElementTypes:
              'Neos.Form:FileUpload':
                properties:
                  # use our custom resource collection for all "FileUpload" form elements
                  resourceCollection: 'formUploads'
                  # Prevent preview link to be created in order to avoid publishing of the Presistent Resource
                  createLinkToFilePreview: false

Thanks to internezzo ag for sponsoring this feature!

Resolves: #114