### PR TITLE
BUGFIX: Remove void return type to stay compabible with PHP 7.0

### DIFF
--- a/Classes/Finishers/EmailFinisher.php
+++ b/Classes/Finishers/EmailFinisher.php
@@ -167,7 +167,7 @@ class EmailFinisher extends AbstractFinisher
         }
     }
 
-    protected function addMessages(SwiftMailerMessage $mail, array $messages): void
+    protected function addMessages(SwiftMailerMessage $mail, array $messages)
     {
         foreach ($messages as $messageFormat => $message) {
             if (count($messages) === 1) {


### PR DESCRIPTION
Fixes https://github.com/neos/form/issues/124