### PR TITLE
Render id={form.identifier} around ConfirmationFinisher

### DIFF
--- a/Classes/Finishers/ConfirmationFinisher.php
+++ b/Classes/Finishers/ConfirmationFinisher.php
@@ -91,6 +91,9 @@ class ConfirmationFinisher extends AbstractFinisher
         } else {
             $message = $this->parseOption('message');
         }
+        
+        // Wrap an identifier div around the finisher message
+        $message = '<div id="'.$formRuntime->getIdentifier().'">'.$message.'</div>';
 
         $formRuntime->getResponse()->setContent($message);
     }


### PR DESCRIPTION
Adds a div container with the form identifier to the `ConfirmationFinisher` so that it is scrolled into view upon invokation

Resolves: #130