### PR TITLE
BUGFIX: mapValueToOption should always return string

### DIFF
--- a/Classes/ViewHelpers/RenderValuesViewHelper.php
+++ b/Classes/ViewHelpers/RenderValuesViewHelper.php
@@ -138,7 +138,7 @@ class RenderValuesViewHelper extends AbstractViewHelper
      */
     protected function mapValueToOption($value, array $options): string
     {
-        return $options[$value] ?? $value;
+        return $options[$value] ?? $value ?? '';
     }
 
     /**


### PR DESCRIPTION
We got problems with forms using select-lists with customized options, when they are optional and broke it down to this method while debugging. 

When the input is optional and not selected, both (`$options[$value]` and `$value`) where empty (`NULL`) in our cases.  
Since the method-signature requires the method to return a string, this fails with `Return value of Neos\Form\ViewHelpers\RenderValuesViewHelper_Original::mapValueToOption() must be of the type string, null returned`.   
Probably this was introduced with the strict-types declaration 

I solved it by simply adding an empty string as fallback-value here and think that should also get into the Neos.Form-Core. 