### PR TITLE
Make allowed_classes configurable when unserializing formState

### DIFF
--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -106,7 +106,7 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
      */
     protected $allowedClassesInFormState;
 
-        /**
+    /**
      * The current page is the page which will be displayed to the user
      * during rendering.
      *

--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -100,6 +100,13 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
     protected $formState;
 
     /**
+     * @Flow\InjectConfiguration(path="formState.allowedClasses")
+     * @var array
+     * @internal
+     */
+    protected $allowedClassesInFormState;
+
+        /**
      * The current page is the page which will be displayed to the user
      * during rendering.
      *
@@ -181,7 +188,12 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
             $this->formState = new FormState();
         } else {
             $serializedFormState = $this->hashService->validateAndStripHmac($serializedFormStateWithHmac);
-            $this->formState = unserialize(base64_decode($serializedFormState), ['allowed_classes' => [FormState::class, \DateTime::class, \DateTimeImmutable::class]]);
+            $allowedClassesInFormState = Arrays::removeEmptyElementsRecursively($this->allowedClassesInFormState);
+            if (is_array($allowedClassesInFormState) && !empty($allowedClassesInFormState)) {
+                $this->formState = unserialize(base64_decode($serializedFormState), ['allowed_classes' => $this->allowedClassesInFormState]);
+            } else {
+                $this->formState = unserialize(base64_decode($serializedFormState));
+            }
         }
     }
 

--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -188,12 +188,7 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
             $this->formState = new FormState();
         } else {
             $serializedFormState = $this->hashService->validateAndStripHmac($serializedFormStateWithHmac);
-            $allowedClassesInFormState = Arrays::removeEmptyElementsRecursively($this->allowedClassesInFormState);
-            if (is_array($allowedClassesInFormState) && !empty($allowedClassesInFormState)) {
-                $this->formState = unserialize(base64_decode($serializedFormState), ['allowed_classes' => $this->allowedClassesInFormState]);
-            } else {
-                $this->formState = unserialize(base64_decode($serializedFormState));
-            }
+            $this->formState = unserialize(base64_decode($serializedFormState), ['allowed_classes' => array_filter($this->allowedClassesInFormState)]);
         }
     }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,6 +5,11 @@ Neos:
       savePath: '%FLOW_PATH_DATA%Forms/'
     supertypeResolver:
       hiddenProperties: {  }
+    formState:
+      allowedClasses:
+        FormState: Neos\Form\Core\Runtime\FormState
+        DateTime: DateTime
+        DateTimeImmutable: DateTimeImmutable
     presets:
       default:
         title: Default


### PR DESCRIPTION
With a new configuration option it is possible to add class names to `allowed_classes ` for `unserialize()` formState within `FormRuntime::initializeFormStateFromRequest`

closes #143 