### PR TITLE
BUGFIX: Allow arbitrary objects in the FormState

### DIFF
--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -181,7 +181,8 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
             $this->formState = new FormState();
         } else {
             $serializedFormState = $this->hashService->validateAndStripHmac($serializedFormStateWithHmac);
-            $this->formState = unserialize(base64_decode($serializedFormState), ['allowed_classes' => [FormState::class, \DateTime::class, \DateTimeImmutable::class]]);
+            /** @noinspection UnserializeExploitsInspection The unserialize call is safe because of the HMAC check above */
+            $this->formState = unserialize(base64_decode($serializedFormState));
         }
     }
 

--- a/Tests/Functional/Fixtures/FormFactories/TwoPageFormWithUploadFactory.php
+++ b/Tests/Functional/Fixtures/FormFactories/TwoPageFormWithUploadFactory.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Form\Tests\Functional\Fixtures\FormFactories;
+
+/*
+ * This file is part of the Neos.Form package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Form\Core\Model\FormDefinition;
+use Neos\Form\Factory\AbstractFormFactory;
+
+class TwoPageFormWithUploadFactory extends AbstractFormFactory
+{
+    public function build(array $configuration, $presetName)
+    {
+        $formDefinition = new FormDefinition('two-page-form-with-upload', $this->getPresetConfiguration($presetName));
+
+        $page1 = $formDefinition->createPage('page1');
+        $page2 = $formDefinition->createPage('page2');
+
+        $fileUpload = $page1->createElement('file', 'Neos.Form:FileUpload');
+        $fileUpload->setProperty('allowedExtensions', ['txt']);
+        $page1->createElement('date', 'Neos.Form:DatePicker');
+        $page2->createElement('text2-1', 'Neos.Form:SingleLineText');
+
+        return $formDefinition;
+    }
+}

--- a/Tests/Functional/Fixtures/dummy.txt
+++ b/Tests/Functional/Fixtures/dummy.txt
@@ -1,0 +1,1 @@
+This is just a dummy file


### PR DESCRIPTION
This fixes a regression introduced with #101 that prevented
objects like images and documents to be persisted in the
Form State, leading to exceptions in multi step forms.

Fixes: #143
Related: #126 #135