### PR TITLE
BUGFIX: Reindex renderables on remove

### DIFF
--- a/Classes/Core/Model/Renderable/AbstractCompositeRenderable.php
+++ b/Classes/Core/Model/Renderable/AbstractCompositeRenderable.php
@@ -70,7 +70,6 @@ abstract class AbstractCompositeRenderable extends AbstractRenderable implements
         }
 
         $reorderedRenderables = [];
-        $i = 0;
         foreach ($this->renderables as $renderable) {
             if ($renderable === $renderableToMove) {
                 continue;
@@ -78,14 +77,11 @@ abstract class AbstractCompositeRenderable extends AbstractRenderable implements
 
             if ($renderable === $referenceRenderable) {
                 $reorderedRenderables[] = $renderableToMove;
-                $renderableToMove->setIndex($i);
-                $i++;
             }
             $reorderedRenderables[] = $renderable;
-            $renderable->setIndex($i);
-            $i++;
         }
         $this->renderables = $reorderedRenderables;
+        $this->reindexRenderables();
     }
 
     /**
@@ -107,23 +103,19 @@ abstract class AbstractCompositeRenderable extends AbstractRenderable implements
         }
 
         $reorderedRenderables = [];
-        $i = 0;
         foreach ($this->renderables as $renderable) {
             if ($renderable === $renderableToMove) {
                 continue;
             }
 
             $reorderedRenderables[] = $renderable;
-            $renderable->setIndex($i);
-            $i++;
 
             if ($renderable === $referenceRenderable) {
                 $reorderedRenderables[] = $renderableToMove;
-                $renderableToMove->setIndex($i);
-                $i++;
             }
         }
         $this->renderables = $reorderedRenderables;
+        $this->reindexRenderables();
     }
 
     /**
@@ -170,8 +162,23 @@ abstract class AbstractCompositeRenderable extends AbstractRenderable implements
             $updatedRenderables[] = $renderable;
         }
         $this->renderables = $updatedRenderables;
+        $this->reindexRenderables();
 
         $renderableToRemove->onRemoveFromParentRenderable();
+    }
+
+    /**
+     * Iterate renderables and set index
+     *
+     * @return void
+     */
+    protected function reindexRenderables()
+    {
+        $i = 0;
+        foreach ($this->renderables as $renderable) {
+            $renderable->setIndex($i);
+            $i++;
+        }
     }
 
     /**

--- a/Tests/Unit/Core/Model/FormDefinitionTest.php
+++ b/Tests/Unit/Core/Model/FormDefinitionTest.php
@@ -583,12 +583,16 @@ class FormDefinitionTest extends UnitTestCase
         $formDefinition = new FormDefinition('foo1');
         $page1 = new Page('bar1');
         $page2 = new Page('bar2');
+        $page3 = new Page('bar3');
         $formDefinition->addPage($page1);
         $formDefinition->addPage($page2);
+        $formDefinition->addPage($page3);
 
-        $formDefinition->removePage($page1);
-        $this->assertNull($page1->getParentRenderable());
-        Assert::assertSame([$page2], $formDefinition->getPages());
+        $formDefinition->removePage($page2);
+        $this->assertNull($page2->getParentRenderable());
+        Assert::assertSame(0, $page1->getIndex());
+        Assert::assertSame(1, $page3->getIndex());
+        Assert::assertSame([$page1, $page3], $formDefinition->getPages());
     }
 
     /**


### PR DESCRIPTION
Removing a renderable should set index of renderables as move does

Fixes neos/form#150