### PR TITLE
TASK: on formRuntime initialization do not overwrite formState values for non existend request arguments

### DIFF
--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -283,6 +283,11 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
         $pageFormValues = [];
         foreach ($page->getElementsRecursively() as $element) {
             $value = Arrays::getValueByPath($requestArguments, $element->getIdentifier());
+
+            if ($value === null) {
+                continue;
+            }
+
             $element->onSubmit($this, $value);
 
             $pageFormValues[$element->getIdentifier()] = $value;


### PR DESCRIPTION
If a form gets initialized with a form state from the URL's query parameter and this form contains a "lastDisplayedPage" the formState gets initialized correctly at first, but than the form framework tries to map the requests argument for the "lastDisplayedPage" to the formState. If the request does not contain these values the already in the formState present values get overwritten with null.

We would suggest to skip the initialization if an argument is not present at all.