### PR TITLE
BUGFIX: Update form state upon element submission

### DIFF
--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -277,11 +277,9 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
             $element->onSubmit($this, $value);
 
             $pageFormValues[$element->getIdentifier()] = $value;
+            $this->formState->setFormValue($element->getIdentifier(), $value);
         }
         $page->onSubmit($this, $pageFormValues);
-        foreach ($pageFormValues as $elementIdentifier => $value) {
-            $this->formState->setFormValue($elementIdentifier, $value);
-        }
 
         // The more parts the path has, the more early it is processed
         usort($propertyPathsForWhichPropertyMappingShouldHappen, function ($a, $b) {


### PR DESCRIPTION
Fixes a regression that was introduced with #149 that led to `onSubmit()` callbacks to only get hold of the form state of previous pages.

With this fix `$formRuntime->getFormState()->getFormValues()` in a custom element will return the previously handled form values, even of the current form page.

Fixes: #156