### PR TITLE
FEATURE: Support additional attributes to be set for SingleLineText a…

### DIFF
--- a/Resources/Private/Form/MultiLineText.html
+++ b/Resources/Private/Form/MultiLineText.html
@@ -1,5 +1,5 @@
 {namespace form=Neos\Form\ViewHelpers}
 <f:layout name="Neos.Form:Field" />
 <f:section name="field">
-	<f:form.textarea property="{element.identifier}" id="{element.uniqueIdentifier}" class="{element.properties.elementClassAttribute}" additionalAttributes="{placeholder: '{element -> form:translateElementProperty(property: \'placeholder\')}', maxlength: element.properties.maxlength}" rows="{element.properties.rows}" cols="{element.properties.cols}" errorClass="{element.properties.elementErrorClassAttribute}"/>
+    <f:form.textarea property="{element.identifier}" id="{element.uniqueIdentifier}" class="{element.properties.elementClassAttribute}" placeholder="{element -> form:translateElementProperty(property: 'placeholder')}" maxlength="{element.properties.maxlength}" rows="{element.properties.rows}" cols="{element.properties.cols}" additionalAttributes="{element.properties.additionalAttributes}" errorClass="{element.properties.elementErrorClassAttribute}"/>
 </f:section>

--- a/Resources/Private/Form/SingleLineText.html
+++ b/Resources/Private/Form/SingleLineText.html
@@ -1,5 +1,5 @@
 {namespace form=Neos\Form\ViewHelpers}
 <f:layout name="Neos.Form:Field" />
 <f:section name="field">
-	<f:form.textfield property="{element.identifier}" id="{element.uniqueIdentifier}" class="{element.properties.elementClassAttribute}" placeholder="{element -> form:translateElementProperty(property: 'placeholder')}" errorClass="{element.properties.elementErrorClassAttribute}" maxlength="{element.properties.maxlength}" />
+	<f:form.textfield property="{element.identifier}" id="{element.uniqueIdentifier}" class="{element.properties.elementClassAttribute}" type="{element.properties.type}" placeholder="{element -> form:translateElementProperty(property: 'placeholder')}" maxlength="{element.properties.maxlength}" additionalAttributes="{element.properties.additionalAttributes}" errorClass="{element.properties.elementErrorClassAttribute}" />
 </f:section>


### PR DESCRIPTION
…nd MultiLineText

Extends the Fluid based default rendering for `SingleLineText` and `MultiLineText` elements such that `additionalAttributes` (and `type` for SingleLineText) can be set via element properties:

    $search = $page1->createElement('search', 'Neos.Form:SingleLineText');
    $search->addValidator(new NotEmptyValidator());
    $search->setLabel('Search');
    $search->setProperty('additionalAttributes', ['inputmode' => 'search']);
    $search->setProperty('type', 'search');

Resolves: #162