### PR TITLE
FEATURE: Allow Eel-Helper in AbstractFinisher for parseOption()

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,9 @@
 
 Neos:
   Form:
+    defaultContext:
+      String: Neos\Eel\Helper\StringHelper
+      Configuration: Neos\Eel\Helper\ConfigurationHelper
     yamlPersistenceManager:
       savePath: '%FLOW_PATH_DATA%Forms/'
     supertypeResolver:

--- a/Documentation/configuring-form-yaml.rst
+++ b/Documentation/configuring-form-yaml.rst
@@ -83,11 +83,13 @@ The following YAML is stored as ``contact.yaml``:
         options:
           templatePathAndFilename: resource://AcmeCom.SomePackage/Private/Templates/Form/Contact.txt
           subject: '{subject}'
-          recipientAddress: 'info@acme.com'
+          recipientAddress: "${Configuration.setting('Foo.Bar.Site.Forms.contact.recipientAddress')}" # reads the recipient address from the configuration. See `allowEelParsingForOptions`
           recipientName: 'Acme Customer Care'
           senderAddress: '{email}'
           senderName: '{name}'
           format: plaintext
+          allowEelParsingForOptions:
+            recipientAddress: true # allow Eel parsing for these values (Security-Note: do not allow user-input options like `senderAddress` or `senderName`)
 
 .. note:: Instead of setting the ``templatePathAndFilename`` option to specify the Fluid template file for the EmailFinisher,
           the template source can also be set directly via the ``templateSource`` option.


### PR DESCRIPTION
Allows the usage of a Eel-Helper in the parseOption-Function This is useful if you have a form and want to send an email to different recipient-addresses based on the configuration context