### PR TITLE
BUGFIX: Fix RenderValuesViewHelper PHP 8+ compatibility

### DIFF
--- a/Classes/ViewHelpers/RenderValuesViewHelper.php
+++ b/Classes/ViewHelpers/RenderValuesViewHelper.php
@@ -96,10 +96,10 @@ class RenderValuesViewHelper extends AbstractViewHelper
      */
     protected function processElementValue(FormElementInterface $element, $value)
     {
-        $properties = $element->getProperties();
         if (is_object($value)) {
             return $this->processObject($element, $value);
         }
+        $properties = $element->getProperties();
         if (isset($properties['options']) && is_array($properties['options'])) {
             if (is_array($value)) {
                 return $this->mapValuesToOptions($value, $properties['options']);

--- a/Classes/ViewHelpers/RenderValuesViewHelper.php
+++ b/Classes/ViewHelpers/RenderValuesViewHelper.php
@@ -97,15 +97,15 @@ class RenderValuesViewHelper extends AbstractViewHelper
     protected function processElementValue(FormElementInterface $element, $value)
     {
         $properties = $element->getProperties();
+        if (is_object($value)) {
+            return $this->processObject($element, $value);
+        }
         if (isset($properties['options']) && is_array($properties['options'])) {
             if (is_array($value)) {
                 return $this->mapValuesToOptions($value, $properties['options']);
             }
 
             return $this->mapValueToOption($value, $properties['options']);
-        }
-        if (is_object($value)) {
-            return $this->processObject($element, $value);
         }
         return $value;
     }

--- a/Classes/ViewHelpers/RenderValuesViewHelper.php
+++ b/Classes/ViewHelpers/RenderValuesViewHelper.php
@@ -151,14 +151,14 @@ class RenderValuesViewHelper extends AbstractViewHelper
     protected function processObject(FormElementInterface $element, $object): string
     {
         $properties = $element->getProperties();
-        if ($object instanceof \DateTime) {
+        if ($object instanceof \DateTimeInterface) {
             if (isset($properties['dateFormat'])) {
                 $dateFormat = $properties['dateFormat'];
                 if (isset($properties['displayTimeSelector']) && $properties['displayTimeSelector'] === true) {
                     $dateFormat .= ' H:i';
                 }
             } else {
-                $dateFormat = \DateTime::W3C;
+                $dateFormat = \DateTimeInterface::W3C;
             }
             return $object->format($dateFormat);
         }


### PR DESCRIPTION
Adjusts the `RenderValuesViewHelper` such that it checks whether the element value to render is an object, _before_ trying to map it.
This resolves an `Illegal offset type` exception that was thrown for `\DateTime` objects with PHP > 7.4