### PR TITLE
TASK: Fix warnings with PHP 8 about incompatible (return) types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.1']
-        flow-versions: ['7.3']
+        php-versions: ['8.0', '8.2']
+        flow-versions: ['8.0', '8.3', '9.0']
         dependencies: ['highest']
 
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,10 @@ jobs:
         php-versions: ['8.0', '8.2']
         flow-versions: ['8.0', '8.3', '9.0']
         dependencies: ['highest']
+        exclude:
+          # excludes Flow 9 on PHP 8.0
+          - php-versions: 8.0
+            flow-versions: 9.0
 
     defaults:
       run:

--- a/Classes/Core/Model/FormDefinition.php
+++ b/Classes/Core/Model/FormDefinition.php
@@ -246,7 +246,6 @@ use Neos\Utility\ObjectAccess;
  */
 class FormDefinition extends Renderable\AbstractCompositeRenderable
 {
-
     /**
      * The identifier of this Form Definition
      *

--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -486,7 +486,7 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
      * @return mixed
      * @api
      */
-    public function offsetExists($identifier)
+    public function offsetExists(mixed $identifier): bool
     {
         return ($this->getElementValue($identifier) !== null);
     }
@@ -512,7 +512,7 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
      * @return mixed
      * @api
      */
-    public function offsetGet($identifier)
+    public function offsetGet($identifier): mixed
     {
         return $this->getElementValue($identifier);
     }
@@ -523,7 +523,7 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
      * @return void
      * @api
      */
-    public function offsetSet($identifier, $value)
+    public function offsetSet($identifier, $value): void
     {
         $this->formState->setFormValue($identifier, $value);
     }
@@ -533,7 +533,7 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
      * @param string $identifier
      * @return void
      */
-    public function offsetUnset($identifier)
+    public function offsetUnset($identifier): void
     {
         $this->formState->setFormValue($identifier, null);
     }

--- a/Classes/Finishers/FlashMessageFinisher.php
+++ b/Classes/Finishers/FlashMessageFinisher.php
@@ -83,16 +83,16 @@ class FlashMessageFinisher extends AbstractFinisher
         switch ($severity) {
             case Message::SEVERITY_NOTICE:
                 $message = new Notice($messageBody, $messageCode, $messageArguments, $messageTitle);
-            break;
+                break;
             case Message::SEVERITY_WARNING:
                 $message = new Warning($messageBody, $messageCode, $messageArguments, $messageTitle);
-            break;
+                break;
             case Message::SEVERITY_ERROR:
                 $message = new Error($messageBody, $messageCode, $messageArguments, $messageTitle);
-            break;
+                break;
             default:
                 $message = new Message($messageBody, $messageCode, $messageArguments, $messageTitle);
-            break;
+                break;
         }
 
         $formRuntime = $this->finisherContext->getFormRuntime();

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "license": "MIT",
     "description": "Extensible and flexible API for building web forms",
     "require": {
-        "php": ">=7.4.0",
-        "neos/flow": ">=6.0 || dev-master"
+        "php": "^8.0",
+        "neos/flow": "^7.3 || ^8.0  || ^9.0"
     },
     "replace": {
         "typo3/form": "self.version"
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0.x-dev"
+            "dev-master": "6.0.x-dev"
         },
         "applied-flow-migrations": [
             "TYPO3.Form-20160601101500",


### PR DESCRIPTION
Fixes warnings like:

`Return type of Neos\Form\Core\Runtime\FormRuntime::offsetUnset($identifier) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`