### PR TITLE
Delete uploaded resource after failed validation

### DIFF
--- a/Classes/Core/Runtime/FormRuntime.php
+++ b/Classes/Core/Runtime/FormRuntime.php
@@ -295,8 +295,8 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
                 $processingRule = $processingRules[$propertyPath];
                 $value = $this->formState->getFormValue($propertyPath);
                 try {
-                    $value = $processingRule->process($value);
 					$isInstanceOfUploadedFileBeforeProcess = $value instanceof FlowUploadedFile;
+					$value = $processingRule->process($value);
 					if ($isInstanceOfUploadedFileBeforeProcess && $value instanceof PersistentResource) {
 						$uploadedResources[] = $value;
 					}
@@ -310,6 +310,7 @@ class FormRuntime implements RootRenderableInterface, \ArrayAccess
 
 		// Delete uploaded resources if errors in form
 		if ($result->hasErrors()) {
+			/** @var PersistentResource $resource */
 			foreach ($uploadedResources as $resource) {
 				$resource->shutdownObject();
 				$resource->preRemove();

--- a/Classes/Validation/FileTypeValidator.php
+++ b/Classes/Validation/FileTypeValidator.php
@@ -43,10 +43,14 @@ class FileTypeValidator extends AbstractValidator
         }
         $fileExtension = $resource->getFileExtension();
         if ($fileExtension === null || $fileExtension === '') {
+			$resource->shutdownObject();
+			$resource->preRemove();
             $this->addError('The file has no file extension.', 1327865808);
             return;
         }
         if (!in_array($fileExtension, $this->options['allowedExtensions'])) {
+			$resource->shutdownObject();
+			$resource->preRemove();
             $this->addError('The file extension "%s" is not allowed.', 1327865764, array($resource->getFileExtension()));
             return;
         }

--- a/Classes/Validation/FileTypeValidator.php
+++ b/Classes/Validation/FileTypeValidator.php
@@ -11,7 +11,9 @@ namespace Neos\Form\Validation;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\Validation\Validator\AbstractValidator;
 
 /**
@@ -20,6 +22,12 @@ use Neos\Flow\Validation\Validator\AbstractValidator;
  */
 class FileTypeValidator extends AbstractValidator
 {
+    /**
+     * @Flow\Inject
+     * @var ResourceManager
+     */
+    protected ResourceManager $resourceManager;
+
     /**
      * @var array
      */
@@ -41,17 +49,18 @@ class FileTypeValidator extends AbstractValidator
             $this->addError('The given value was not a PersistentResource instance.', 1327865587);
             return;
         }
+
         $fileExtension = $resource->getFileExtension();
+
         if ($fileExtension === null || $fileExtension === '') {
-			$resource->shutdownObject();
-			$resource->preRemove();
             $this->addError('The file has no file extension.', 1327865808);
+            $this->resourceManager->deleteResource($resource);
             return;
         }
+
         if (!in_array($fileExtension, $this->options['allowedExtensions'])) {
-			$resource->shutdownObject();
-			$resource->preRemove();
             $this->addError('The file extension "%s" is not allowed.', 1327865764, array($resource->getFileExtension()));
+            $this->resourceManager->deleteResource($resource);
             return;
         }
     }


### PR DESCRIPTION
**Problem**: When a file is uploaded using the `FormUpload` element, it is immediately saved to the resource collection upon form submission. However, if the file is later deemed invalid, it still occupies server storage, leading to unnecessary and potentially significant consumption of storage space.

**Implementation**: The `\Neos\Form\Validation\FileTypeValidator` now utilizes an injected resource manager. If a file fails validation, the resource manager deletes the corresponding file and entry in the DB, preventing invalid files from being permanently stored and conserving server storage space.