### PR TITLE
BUGFIX: catch InvalidHmacErrors in DefaultFormStateInitializer

### DIFF
--- a/Classes/FormState/DefaultFormStateInitializer.php
+++ b/Classes/FormState/DefaultFormStateInitializer.php
@@ -16,6 +16,8 @@ namespace Neos\Form\FormState;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Cryptography\HashService;
+use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
+use Neos\Flow\Security\Exception\InvalidHashException;
 use Neos\Form\Core\Model\FormDefinition;
 use Neos\Form\Core\Runtime\FormState;
 
@@ -31,7 +33,11 @@ class DefaultFormStateInitializer implements FormStateInitializerInterface
     {
         $serializedFormStateWithHmac = $actionRequest->getInternalArgument('__state');
         if ($serializedFormStateWithHmac !== null) {
-            $serializedFormState = $this->hashService->validateAndStripHmac($serializedFormStateWithHmac);
+            try {
+                $serializedFormState = $this->hashService->validateAndStripHmac($serializedFormStateWithHmac);
+            } catch (InvalidArgumentForHashGenerationException | InvalidHashException) {
+                return new FormState();
+            }
             /** @noinspection UnserializeExploitsInspection The unserialize call is safe because of the HMAC check above */
             return unserialize(base64_decode($serializedFormState));
         }


### PR DESCRIPTION
Hey there, just saw a bot attack against one of our services trying to exploit this on-caught exception.
Not sure if such hmac-manipulations should be logged using the security-logger?